### PR TITLE
Remove assumption that CoaL external NIC is e1000g0

### DIFF
--- a/networking/gen-coal.sh
+++ b/networking/gen-coal.sh
@@ -44,15 +44,12 @@ function get_server
 	gc_server=$uuid
 }
 
-#
-# Coal always has e1000g0 for the external network.
-#
 function get_mac
 {
 	local mac
 
-	mac=$(dladm show-phys -mpo address e1000g0)
-	[[ $? -eq 0 ]] || fatal "failed to run dladm"
+	mac=$(nictagadm list -p -d, | awk -F, '$1 == "external" { print $2 }')
+	[[ $? -eq 0 ]] || fatal "failed to run nictagadm/awk"
 	[[ -z "$mac" ]] && fatal "found an empty mac address"
 	gc_mac=$mac
 }


### PR DESCRIPTION
While doing some follow-up testing based on https://blog.shalman.org/running-sdc-coal-on-smartos/ I realized two possible issues:
1. If I got the order of the NICs wrong this assumption would be invalid
2. I am also testing out use of vioif https://github.com/nshalman/illumos-joyent/commit/3e39bb32362ad76b17a794510aabdb81a5548908 which alters the name of the device and makes this just fail outright.

This patch addresses both of those issues.
Feedback requested.