### PR TITLE
MANTA-3274 show how to run sdc-manta 'make test' when developing on non-smartos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /node_modules
 /tmp
+/etc
 build
 docs/*.json
 docs/*.html

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,16 @@ include ./tools/mk/Makefile.node_deps.defs
 NODE_PREBUILT_VERSION=v0.10.32
 NODE_PREBUILT_TAG=zone
 NODE_PREBUILT_IMAGE=fd2cc906-8938-11e3-beab-4359c665ac99
-include ./tools/mk/Makefile.node_prebuilt.defs
+ifeq ($(shell uname -s),SunOS)
+	include ./tools/mk/Makefile.node_prebuilt.defs
+	NODE_EXEC_DIR=$(TOP)/build/node/bin
+else
+	NPM=npm
+	NODE=node
+	NPM_EXEC=$(shell which npm)
+	NODE_EXEC=$(shell which node)
+	NODE_EXEC_DIR=$(shell dirname $(NODE_EXEC))
+endif
 
 MAN_INROOT	 = docs/man
 MAN_OUTROOT	 = man
@@ -105,7 +114,7 @@ prepush: check-probe-files
 
 .PHONY: test
 test: | $(CATEST)
-	PATH="$(TOP)/build/node/bin:$$PATH" $(CATEST) -a
+	PATH="$(NODE_EXEC_DIR):$$PATH" $(CATEST) -a
 
 $(CATEST): deps/catest/.git
 
@@ -155,7 +164,9 @@ publish: release
 CLEAN_FILES += node_modules
 
 include ./tools/mk/Makefile.deps
-include ./tools/mk/Makefile.node_prebuilt.targ
+ifeq ($(shell uname -s),SunOS)
+	include ./tools/mk/Makefile.node_prebuilt.targ
+endif
 include ./tools/mk/Makefile.node_deps.targ
 include ./tools/mk/Makefile.targ
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 -->
 
 <!--
-    Copyright (c) 2016, Joyent, Inc.
+    Copyright (c) 2017, Joyent, Inc.
 -->
 
 # sdc-manta
@@ -65,7 +65,26 @@ and if warranted, get a code review.
 configuration file in etc/config.json.  The easiest way to create one is to copy
 the template in sapi\_manifests/manta/template and fill in the details for your
 environment, or else copy the configuration file directly out of a deployed
-sdc-manta zone in your environment.
+sdc-manta zone in your environment.  This assumes that you are developing on
+SmartOS. Read the next section if not.
+
+
+## `make prepush` if you build on non-SmartOS
+
+If you build on, say, MacOS, you will not be able to run the test suite
+(which is part of `make prepush`). An alternative is to:
+
+1. run `make prepush` on your Mac (ignoring the test failures); and
+
+2. sync your local changes to a deployed `manta0` zone (e.g. in COAL) and test
+   there. This can be done as follows:
+
+        ./tools/rsync-to $HEADNODE   # e.g. ./tools/rsync-to root@10.99.99.7
+        ssh $HEADNODE
+        sdc-login -l manta
+        cd /opt/smartdc/manta-deployment
+        pkgin in -y make
+        make test
 
 
 ## Adding a new Manta service

--- a/tools/rsync-to
+++ b/tools/rsync-to
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+
+#
+# Copyright (c) 2017, Joyent, Inc.
+#
+
+#
+# Rsync the master in this working copy to the install on the given HN.
+#
+
+#set -o xtrace
+set -o errexit
+
+TOP=$(cd $(dirname $0)/../; pwd)
+NODE=$1
+
+if [[ -z "$MANTA_ZONE" ]]; then
+    MANTA_ZONE=$(ssh $NODE "vmadm lookup -1 alias=manta0" 2>/dev/null)
+fi
+echo "MANTA_ZONE: $MANTA_ZONE"
+
+extraOpts=
+if [[ $(uname -s) != "SunOS" ]]; then
+    extraOpts="--exclude *.node --exclude build"
+fi
+
+# Note that we include tools/ and deps/ here to support running the test suite
+# in the rsync'd-to manta0 zone.
+rsync -av ${TOP}/ \
+    $NODE:/zones/$MANTA_ZONE/root/opt/smartdc/manta-deployment/ \
+    $extraOpts \
+    --exclude .git/ \
+    --exclude /boot/ \
+    --exclude /deps/ \
+    --exclude /tmp/


### PR DESCRIPTION
This PR was migrated-from-gerrit, <https://cr.joyent.us/#/c/1976/>. 
The raw archive of this CR is [here](https://github.com/joyent/gerrit-migration/tree/master/archive/1976).
See [MANTA-4594](https://smartos.org/bugview/MANTA-4594) for info on Joyent Eng's migration from Gerrit.

## CR discussion

##### @trentm commented at 2017-05-18T23:18:29

> Patch Set 1:
> 
> New commits:  
>     commit 7feb8435c572140c265f4298efbe47496bf75dac  
>     rsync-to script

##### @trentm commented at 2017-06-23T18:32:34

> Patch Set 2:
> 
> New commits:  
>     commit f33acb2a704e39e9acb4eb9375677aaa54b681e6  
>     tweaks for dev on macOS

##### @trentm commented at 2017-07-13T16:06:26

> Patch Set 3:
> 
> New commits:  
>     commit 8a5baf31bd4dc34a253796f5c848d92dfd54a97c  
>     tweaks for dev on macOS

##### @chudley commented at 2017-07-14T14:30:47

> Patch Set 3:
> 
> This looks useful. It's pretty much what I do manually when working on the joyent/sdc-manta codebase.
> 
> I can see we're syncing deps/, but I don't know what this would do if `make` had been run already on the MacOS machine before syncing. Would this lead to MacOS-specific binaries being synced to the manta0 zone, or does the "--exclude build" prevent us from deploying these build artefacts, even if they're in subdirectories?

##### @trentm commented at 2017-07-14T18:02:03

> Patch Set 3:
> 
> Ah, thanks. I should get it to skip deps.

##### @trentm commented at 2017-07-14T18:03:06

> Patch Set 4:
> 
> New commits:  
>     commit 6b0d8542e7d569e6d1be0d96f4e8630cc45f93b9  
>     skip deps, per CR feedback

##### @trentm commented at 2017-07-31T16:29:02

> Patch Set 5:
> 
> New commits:  
>     commit f34cd51cdbee26e35c1374aa6a76051bb7f92758  
>     skip deps, per CR feedback
>     
>     commit 3e71209f5a75306fbff49e707a579b44aef28f42  
>     tweaks for dev on macOS

##### @trentm commented at 2017-07-31T16:31:08

> Patch Set 5:
> 
> @richard: poke

##### @chudley commented at 2017-08-01T09:46:26

> Patch Set 5:
> 
> (3 comments)
> 
> ###### Makefile#66  
> 
> I'm a little ignorant on our Makefiles so some of this could quite possibly be ignored, but I've gathered that we're setting NPM and NODE here because we're no longer letting "Makefile.node_prebuilt.defs" do it (because we're running on MacOS).
> 
> I can see that we're not using full paths, presumably relying on the developer's PATH to find these. "Makefile.node_prebuilt.defs" will use full paths for these, so is relying on PATH going to be OK here?
> 
> Is there anything else from "Makefile.node_prebuilt.defs" that we might be lacking by not including it?
> 
> Lastly, where do we stand on the situation where a developer could be running a different version of node and the suite passes, but it fails on the prebuilt version?
> 
> ###### README.md#87  
> 
> Could we do the `make prepush` here instead of doing it in step 1?
> 
> Alternatively, seeing as `make prepush` is a check and test, maybe step 1 could just be to run `make check`? I understand `make check` to work on MacOS.
> 
> ###### tools/rsync-to#32  
> 
> Nitty, but the comment here still references that "deps/" will be moved, but we've added it to the exclude list.