### PR TITLE
MANTA-3674 manta-adm should have a channel guard

### DIFF
--- a/cmd/manta-adm.js
+++ b/cmd/manta-adm.js
@@ -876,12 +876,24 @@ MantaAdm.prototype.do_update = function (subcmd, opts, args, callback)
 		function fetchDeployed(_, stepcb) {
 			adm.fetchDeployed(stepcb);
 		},
+		function determineDefaultChannel(_, stepcb) {
+			if (opts.skip_verify_channel) {
+				stepcb();
+				return;
+			}
+			adm.determineSdcChannel(stepcb);
+		},
 		function generatePlan(_, stepcb) {
 			adm.generatePlan({
 				service: service,
 				noreprovision: opts.no_reprovision,
 				experimental: opts.experimental
 			}, stepcb);
+		},
+		function verifyPlan(_, stepcb) {
+			adm.verifyPlan(
+			    {skip_verify_channel: opts.skip_verify_channel},
+			    stepcb);
 		},
 		function dumpPlan(_, stepcb) {
 			adm.execPlan(process.stdout, process.stderr,
@@ -954,6 +966,13 @@ MantaAdm.prototype.do_update.options = [
     'names': [ 'experimental', 'X' ],
     'type':  'bool',
     'help': 'Allow deployment of experimental services'
+},
+{
+    'names': [ 'skip-verify-channel' ],
+    'type': 'bool',
+    'help': 'When provisioning an image, avoid verifying that this image ' +
+    'comes from the default update channel for this datacenter',
+    'default': false
 } ];
 
 MantaAdm.prototype.do_zk = MantaAdmZk;

--- a/cmd/manta-init.js
+++ b/cmd/manta-init.js
@@ -7,7 +7,7 @@
  */
 
 /*
- * Copyright (c) 2019, Joyent, Inc.
+ * Copyright 2019 Joyent, Inc.
  */
 
 /*
@@ -53,6 +53,16 @@ var CONCURRENCY = 10;
 optimist.usage('Usage:\tmanta-init -e <email>');
 
 var ARGV = optimist.options({
+	'B': {
+		alias: 'branch',
+		describe: 'the branch substring to use when looking for images '
+			+ '(default: no filter)',
+		default: ''
+	},
+	'C': {
+		alias: 'channel',
+		describe: 'the channel to use'
+	},
 	'c': {
 		alias: 'concurrent_downloads',
 		describe: 'number of concurrent image downloads (default: 10)'
@@ -217,17 +227,24 @@ function findLatestImage(service, cb) {
 	var log = self.log;
 
 	var image_name = services.serviceNameToImageName(service);
-	var version_substr = 'master';
+	var version_substr = ARGV.branch;
+	var channel = ARGV.channel;
 
-	log.info('finding image %s (version substr "%s") for service %s',
-	    image_name, version_substr, service);
+	log.info('finding image %s for service %s on channel "%s"',
+	    image_name, service, channel);
 
 	var onSearchFinish = function (err, image) {
 		if (err) {
 			log.error(err);
 			return (cb(err));
 		}
-
+		if (image === undefined) {
+			var msg = sprintf(
+			    'Unable to find image %s for %s on channel "%s"',
+			    image_name, service, channel);
+			log.error(msg);
+			return (cb(new Error(msg)));
+		}
 		log.info({ image: image }, 'found image %s for %s',
 		    image_name, service);
 
@@ -236,7 +253,7 @@ function findLatestImage(service, cb) {
 
 	/*
 	 * If -n is used, find the most recent image which is installed in
-	 * this datacenter's IMGAPI.
+	 * this datacenter's IMGAPI, assuming it matches our version_substr.
 	 */
 	if (ARGV.n) {
 		return (findLatestLocalImage(
@@ -245,7 +262,14 @@ function findLatestImage(service, cb) {
 
 	var filters = {};
 	filters.name = image_name;
-	filters.version = '~' + version_substr;
+	if (version_substr.length > 0) {
+		log.info('search restricted to version substring: %s',
+		    version_substr);
+		filters.version = '~' + version_substr;
+	}
+	if (channel.length > 0) {
+		filters.channel = channel;
+	}
 	log.info({ filters: filters }, 'search for images');
 
 	remote_imgapi.listImages(filters, function (err, images) {
@@ -263,12 +287,15 @@ function findLatestLocalImage(image_name, version_substr, cb) {
 	var imgapi = self.IMGAPI;
 	var log = self.log;
 
-	log.info('search for image %s (version substr "%s") restricted ' +
-	    'to local images', image_name, version_substr);
+	log.info('search for image %s restricted to local images', image_name);
 
 	var filters = {};
 	filters.name = image_name;
-	filters.version = '~' + version_substr;
+	if (version_substr.length > 0) {
+		log.info('search restricted to version substring: %s',
+		    version_substr);
+		filters.version = '~' + version_substr;
+	}
 
 	imgapi.listImages(filters, function (err, images) {
 		if (err) {
@@ -395,6 +422,9 @@ if (typeof (ARGV.c) == 'number' && ARGV.c > 0 && ARGV.c < 128 &&
 	 */
 	usage('unsupported value for "-c" option ' +
 	    '(must be a positive integer less than 128)');
+}
+if (typeof (ARGV.channel) === 'boolean') {
+	ARGV.channel = '';
 }
 
 var pipelineFuncs = [
@@ -695,6 +725,26 @@ var pipelineFuncs = [
 
 			log.info('loaded manifests from %s', dirname);
 			return (cb(null));
+		});
+	},
+
+	function determineDefaultChannel(_, cb) {
+		var log = self.log;
+		// If the user passed a -C argument, then we're done
+		if (ARGV.channel !== undefined) {
+			return (cb(null));
+		}
+
+		log.info('determining update_channel from sapi');
+		common.getSdcChannel.call(self,
+			{}, function (err, channel) {
+			if (!err) {
+				ARGV.channel = channel;
+				return (cb(null));
+			}
+			log.error(
+			    err, 'failed to determine sdc update_channel');
+			return (cb(err));
 		});
 	},
 

--- a/docs/man/man1/manta-adm.md
+++ b/docs/man/man1/manta-adm.md
@@ -20,7 +20,7 @@ manta-adm - administer a Manta deployment
 
 `manta-adm show [-l LOG_FILE] [-js] SERVICE`
 
-`manta-adm update [-l LOG_FILE] [-n] [-y] [--no-reprovision] FILE [SERVICE]`
+`manta-adm update [-l LOG_FILE] [-n] [-y] [--no-reprovision] [--skip-verify-channel] FILE [SERVICE]`
 
 `manta-adm zk list [-l LOG_FILE] [-H] [-o FIELD...]`
 
@@ -790,6 +790,12 @@ options described above, plus:
   When upgrading a zone, always provision a new zone and deprovision the
   previous one, rather than reprovisioning the existing one.
 
+`--skip-verify-channel`
+  When upgrading, do not verify that the images being provisioned or
+  reprovisioned are present on the "remote" (usually https://updates.joyent.com)
+  imgapi channel that was set on the headnode using the `sdcadm channel`
+  command.
+
 If `SERVICE` is specified, then only instances of the named service are
 changed.
 
@@ -900,7 +906,7 @@ and `-y/--confirm` options described above.
 
 ## COPYRIGHT
 
-Copyright (c) 2019, Joyent Inc.
+Copyright 2019 Joyent, Inc.
 
 ## SEE ALSO
 

--- a/docs/man/man1/manta-init.md
+++ b/docs/man/man1/manta-init.md
@@ -1,4 +1,4 @@
-# MANTA-INIT 1 "2016" Manta "Manta Operator Commands"
+# MANTA-INIT 1 "2019" Manta "Manta Operator Commands"
 
 ## NAME
 
@@ -23,6 +23,20 @@ run this command except as documented in the Manta Operator's Guide.**
 
 
 ## OPTIONS
+
+`-B, --branch BRANCH`
+  Specifies a substring which must be present in the version string of the
+  images to be downloaded. The default for this value is the empty string,
+  which means that the latest images on the given channel are used, regardless
+  of their branch.
+
+`-C, --channel CHANNEL`
+  Specifies the updates.joyent.com channel from which images should be
+  downloaded unless `-n` is used. By default, this value is set to the current
+  value of `update_channel` in this data-center, obtained from the `sdc`
+  application in SAPI. Use the `sdcadm channel` command to view or change
+  the default value. Using an empty string as the argument will cause
+  manta-init to search for images on any channel.
 
 `-c, --concurrent_downloads N`
   Specifies that no more than `N` zone images should be downloaded
@@ -71,7 +85,7 @@ Non-zero
 
 ## COPYRIGHT
 
-Copyright (c) 2016 Joyent Inc.
+Copyright 2019 Joyent, Inc.
 
 ## SEE ALSO
 

--- a/docs/man/man1/manta-init.md
+++ b/docs/man/man1/manta-init.md
@@ -35,8 +35,7 @@ run this command except as documented in the Manta Operator's Guide.**
   downloaded unless `-n` is used. By default, this value is set to the current
   value of `update_channel` in this data-center, obtained from the `sdc`
   application in SAPI. Use the `sdcadm channel` command to view or change
-  the default value. Using an empty string as the argument will cause
-  manta-init to search for images on any channel.
+  the default value.
 
 `-c, --concurrent_downloads N`
   Specifies that no more than `N` zone images should be downloaded

--- a/lib/adm.js
+++ b/lib/adm.js
@@ -529,6 +529,11 @@ function maAdm(log)
 	 */
 	this.ma_gzinfo = null;
 
+	/*
+	 * The default image update channel configured for the datacenter.
+	 */
+	this.ma_channel = null;
+
 	/* Update information */
 	this.ma_plan = null;
 	this.ma_instances_wanted = null;
@@ -3864,6 +3869,25 @@ maAdm.prototype.readInstanceMetadataConfigRaw = function (contents)
 	return (null);
 };
 
+maAdm.prototype.determineSdcChannel = function (cb)
+{
+	var self = this;
+	var opts = {
+	    'sapi': self.ma_sdc.SAPI,
+	    'log': self.ma_log
+	};
+	common.getSdcChannel(opts, function (err, channel) {
+		if (err) {
+			self.ma_log.info('Unable to determine channel' + err);
+			cb(new VError(err));
+			return;
+		}
+		self.ma_channel = channel;
+		self.ma_log.info('SDC update channel is ' + self.ma_channel);
+		cb();
+	});
+};
+
 /*
  * Assuming we've already loaded the current deployed configuration and the
  * user-specified configuration, generate a plan to make reality match what the
@@ -4095,6 +4119,106 @@ maAdm.prototype.generatePlan = function (opts, callback)
 	}
 
 	setTimeout(callback, 0);
+};
+
+/*
+ * Determine whether the plan that was generated adheres to any restrictions
+ * that are in place.
+ * For now the only check implemented is to ensure that all images for
+ * deployment are available on the specific imgapi channel set by
+ * 'sdcadm channel set' on the 'remote_imgapi' set in etc/config.json.
+ *
+ * Options:
+ * - skip_verify_channel: if true, we avoid verifying that each image to be
+ *   provisioned is present on the defined SDC updates.joyent.com channel.
+ */
+maAdm.prototype.verifyPlan = function (opts, cb)
+{
+	assert.ok(this.ma_plan !== null);
+	assertplus.object(opts, 'opts');
+	assertplus.func(cb, 'cb');
+	assertplus.bool(opts.skip_verify_channel, 'opts.skip_verify_channel');
+
+	var self = this;
+
+	if (opts.skip_verify_channel) {
+		return (cb());
+	}
+	/*
+	 * If we're doing channel verification, go through our plan,
+	 * checking that each new image exists on that channel. To do this,
+	 * find the set of new image uuids per-service across all compute nodes
+	 * in the plan.
+	 */
+	// We don't have a Set() object, so instead use unique Object keys
+	var services_by_image = {};
+	for (var svcname in this.ma_plan) {
+		for (var cnid in this.ma_plan[svcname]) {
+			for (var i = 0;
+			    i < this.ma_plan[svcname][cnid].length;
+			    i++) {
+				var plan_op = this.ma_plan[svcname][cnid][i];
+				var new_image = null;
+				if (plan_op.action === 'provision') {
+					new_image = plan_op.IMAGE;
+				} else if (plan_op.action === 'reprovision') {
+					new_image = plan_op.new_image;
+				}
+				if (new_image) {
+					services_by_image[new_image] = svcname;
+				}
+			}
+		}
+	}
+
+	var imgapi_opts = {'channel': self.ma_channel};
+
+	// An array of strings, later used to form an error message.
+	var imagesNotInTheChannel = [];
+	// process each of the images in series
+	vasync.forEachParallel({
+	    inputs: Object.keys(services_by_image),
+	    func: function channelCheckOneImage(imageUuid, nextImage) {
+			self.ma_log.debug(
+			    sprintf(
+				    'looking up image %s for service %s ' +
+				    'on channel %s',
+				    imageUuid, services_by_image[imageUuid],
+				    self.ma_channel));
+			    self.ma_sdc.REMOTE_IMGAPI.getImage(
+				    imageUuid, imgapi_opts,
+			    function getImage(err, image) {
+				if (err) {
+					// note that we don't invoke the
+					// err callback since vasync will
+					// then report only
+					// 'the first of n errors'
+					var missing = sprintf('%s (%s)',
+					    imageUuid,
+					    services_by_image[imageUuid]);
+					self.ma_log.debug(
+					    'missing image ' + missing);
+					imagesNotInTheChannel.push(missing);
+					nextImage();
+				} else {
+					nextImage();
+				}
+			});
+		}
+	}, function finish(err) {
+		if (err) {
+			cb(err);
+		} else if (imagesNotInTheChannel.length > 0) {
+			cb(new VError(
+				'The following images were not found on ' +
+				'the \'' + self.ma_channel + '\' channel ' +
+				'and cannot be provisioned. ' +
+				'(Use --skip-verify-channel to override): ' +
+				imagesNotInTheChannel.join(', ')));
+		} else {
+			cb();
+		}
+	});
 };
 
 /*

--- a/lib/adm.js
+++ b/lib/adm.js
@@ -3879,11 +3879,17 @@ maAdm.prototype.determineSdcChannel = function (cb)
 	common.getSdcChannel(opts, function (err, channel) {
 		if (err) {
 			self.ma_log.info('Unable to determine channel' + err);
-			cb(new VError(err));
+			cb(err);
 			return;
 		}
 		self.ma_channel = channel;
-		self.ma_log.info('SDC update channel is ' + self.ma_channel);
+		if (channel !== null) {
+			self.ma_log.info(
+				'SDC update channel is ' + self.ma_channel);
+		} else {
+			self.ma_log.info(
+				'SDC update channel has not been set');
+		}
 		cb();
 	});
 };
@@ -4171,50 +4177,68 @@ maAdm.prototype.verifyPlan = function (opts, cb)
 		}
 	}
 
-	var imgapi_opts = {'channel': self.ma_channel};
+	var imgapi_opts = {};
+	/*
+	 * The channel can be null when e.g. 'sdcadm channel unset' causes our
+	 * SAPI entry to have that metadata removed. In that case, when
+	 * searching for images, we look in the default channel as configured on
+	 * the updates imgapi server itself.
+	 */
+	if (self.ma_channel !== null) {
+		imgapi_opts.channel = self.ma_channel;
+	}
 
 	// An array of strings, later used to form an error message.
 	var imagesNotInTheChannel = [];
-	// process each of the images in series
+	// process each of the images in parallel
 	vasync.forEachParallel({
 	    inputs: Object.keys(services_by_image),
 	    func: function channelCheckOneImage(imageUuid, nextImage) {
-			self.ma_log.debug(
-			    sprintf(
-				    'looking up image %s for service %s ' +
-				    'on channel %s',
-				    imageUuid, services_by_image[imageUuid],
-				    self.ma_channel));
-			    self.ma_sdc.REMOTE_IMGAPI.getImage(
-				    imageUuid, imgapi_opts,
-			    function getImage(err, image) {
-				if (err) {
-					// note that we don't invoke the
-					// err callback since vasync will
-					// then report only
-					// 'the first of n errors'
-					var missing = sprintf('%s (%s)',
-					    imageUuid,
-					    services_by_image[imageUuid]);
-					self.ma_log.debug(
-					    'missing image ' + missing);
-					imagesNotInTheChannel.push(missing);
-					nextImage();
-				} else {
-					nextImage();
-				}
-			});
+		self.ma_log.debug(
+			    'looking up image %s for service %s on ' +
+			    'channel %s',
+			    imageUuid, services_by_image[imageUuid],
+			    self.ma_channel);
+		self.ma_sdc.REMOTE_IMGAPI.getImage(imageUuid, imgapi_opts,
+			function getImage(err, image) {
+			if (err) {
+				// note that we don't invoke the err callback
+				// since vasync will then report only
+				// 'the first of n errors'
+				var missing = sprintf('%s (%s)', imageUuid,
+				    services_by_image[imageUuid]);
+				self.ma_log.debug('missing image ' + missing);
+				imagesNotInTheChannel.push(missing);
+				nextImage();
+			} else {
+				nextImage();
+			}
+		});
 		}
 	}, function finish(err) {
 		if (err) {
 			cb(err);
 		} else if (imagesNotInTheChannel.length > 0) {
-			cb(new VError(
-				'The following images were not found on ' +
-				'the \'' + self.ma_channel + '\' channel ' +
-				'and cannot be provisioned. ' +
-				'(Use --skip-verify-channel to override): ' +
-				imagesNotInTheChannel.join(', ')));
+			var msg;
+			if (!self.ma_channel) {
+				msg = sprintf(
+				    'The following images were not found on ' +
+				    'the default updates channel and ' +
+				    'cannot be provisioned. ' +
+				    '(Use --skip-verify-channel to ' +
+				    'override): %s',
+				    imagesNotInTheChannel.join(', '));
+			} else {
+				msg = sprintf(
+				    'The following images were not found on ' +
+				    'the "%s" channel and cannot be ' +
+				    'provisioned. ' +
+				    '(Use --skip-verify-channel to ' +
+				    'override): %s',
+				    self.ma_channel,
+				    imagesNotInTheChannel.join(', '));
+			}
+			cb(new VError(msg));
 		} else {
 			cb();
 		}

--- a/lib/common.js
+++ b/lib/common.js
@@ -937,6 +937,46 @@ function getServerNicTags(cb) {
 	});
 }
 
+/*
+ * Query SAPI for the current update_channel. The callback function takes
+ * the form function(err, update_channel)
+ * This function can have a SAPI and bunyan log object passed as options,
+ * or will fallback to objects initialized by initSdcClients and self.log
+ * if those are not provided.
+ */
+function getSdcChannel(opts, cb) {
+	assert.object(opts, 'opts');
+	assert.optionalObject(opts.sapi, 'opts.sapi');
+	assert.optionalObject(opts.log, 'opts.log');
+	assert.func(cb, 'cb');
+
+	var sapi = opts.sapi;
+	var log = opts.log;
+	if (opts.sapi === undefined) {
+		sapi = this.SAPI;
+	}
+	if (opts.log === undefined) {
+		log = this.log;
+	}
+
+	var search = {};
+	search.name = 'sdc';
+	search.include_master = true;
+
+	sapi.listApplications(search, function (err, apps) {
+		if (err) {
+			log.error(err, 'failed to list applications');
+			return (cb(err));
+		}
+
+		log.debug('found sdc application');
+		assert.ok(apps.length <= 1);
+		assert.string(apps[0].metadata.update_channel);
+
+		return (cb(null, apps[0].metadata.update_channel));
+	});
+}
+
 exports.shuffle = shuffle;
 exports.domainToPath = domainToPath;
 exports.initSdcClients = initSdcClients;
@@ -953,3 +993,4 @@ exports.sortObjectsByProps = sortObjectsByProps;
 exports.fmtDuration = fmtDuration;
 exports.updateNetworkUsers = updateNetworkUsers;
 exports.getServerNicTags = getServerNicTags;
+exports.getSdcChannel = getSdcChannel;

--- a/lib/common.js
+++ b/lib/common.js
@@ -943,25 +943,22 @@ function getServerNicTags(cb) {
  * This function can have a SAPI and bunyan log object passed as options,
  * or will fallback to objects initialized by initSdcClients and self.log
  * if those are not provided.
+ * The update channel can be empty, (e.g. if `sdcadm channel unset`)
+ * in which case we set return a null.
  */
 function getSdcChannel(opts, cb) {
 	assert.object(opts, 'opts');
-	assert.optionalObject(opts.sapi, 'opts.sapi');
-	assert.optionalObject(opts.log, 'opts.log');
+	assert.object(opts.sapi, 'opts.sapi');
+	assert.object(opts.log, 'opts.log');
 	assert.func(cb, 'cb');
 
 	var sapi = opts.sapi;
 	var log = opts.log;
-	if (opts.sapi === undefined) {
-		sapi = this.SAPI;
-	}
-	if (opts.log === undefined) {
-		log = this.log;
-	}
 
-	var search = {};
-	search.name = 'sdc';
-	search.include_master = true;
+	var search = {
+		name: 'sdc',
+		include_master: true
+	};
 
 	sapi.listApplications(search, function (err, apps) {
 		if (err) {
@@ -971,8 +968,12 @@ function getSdcChannel(opts, cb) {
 
 		log.debug('found sdc application');
 		assert.ok(apps.length <= 1);
+		if (!apps[0].metadata.update_channel) {
+			log.info('No channel data set in SAPI. ' +
+				'Using default server update channel.');
+			return (cb(null, null));
+		}
 		assert.string(apps[0].metadata.update_channel);
-
 		return (cb(null, apps[0].metadata.update_channel));
 	});
 }

--- a/lib/common.js
+++ b/lib/common.js
@@ -967,7 +967,7 @@ function getSdcChannel(opts, cb) {
 		}
 
 		log.debug('found sdc application');
-		assert.ok(apps.length <= 1);
+		assert.ok(apps.length === 1);
 		if (!apps[0].metadata.update_channel) {
 			log.info('No channel data set in SAPI. ' +
 				'Using default server update channel.');


### PR DESCRIPTION
**This PR was migrated from https://github.com/joyent/sdc-manta/pull/6**

MANTA-2769 manta-init should be channel aware
MANTA-4159 manta-init should have an option to specify an image version substring
MANTA-3674 manta-adm should have a channel guard


This PR was migrated-from-gerrit, <https://cr.joyent.us/#/c/6808/>.
The raw archive of this CR is [here](https://github.com/joyent/gerrit-migration/tree/master/archive/6808).
See [MANTA-4594](https://smartos.org/bugview/MANTA-4594) for info on Joyent Eng's migration from Gerrit.

## CR discussion

##### @timfoster commented at 2019-08-19T15:38:33

> Patch Set 1:
> 
> New commits:  
>     commit 0f70ed94a320e8ccc869dfa16f0d6d4713b16b50  
>     MANTA-2769 manta-init should be channel aware

##### @timfoster commented at 2019-08-19T15:52:53

> Patch Set 2:
> 
> New commits:  
>     commit 4894f32348e2db81439970a97d8a3ba79db02fa3  
>     fix 'make check' errors

##### @timfoster commented at 2019-08-20T10:15:40

> Patch Set 3:
> 
> New commits:  
>     commit 199d8a9de142663146d544059e0abd77884f3118  
>     Switch to a default -B value of ''

##### @timfoster commented at 2019-09-18T11:16:05

> Patch Set 4:
> 
> New commits:  
>     commit 798ac0c8c86d7ee315fa25eea9f4e5ba75d65e4e  
>     MANTA-3674 manta-adm should have a channel guard
>     
>     commit a28814f2334a61607edac1b02bf03339b838490a  
>     MANTA-2769 manta-init should be channel aware

##### @timfoster commented at 2019-09-18T11:29:11

> Patch Set 4:
> 
> This needs a little more work - the changes were developed on two
> branches, and I now want to see if I can refactor the lookup of the SAPI
> 'channel' option so that there's less duplicated code.

##### @timfoster commented at 2019-09-19T08:28:29

> Patch Set 5:
> 
> New commits:  
>     commit 3e29ce504d3dd40b276c6346fa63a9066af8d3a1  
>     share SAPI channel lookup code between manta-init and manta-adm
>     
>     commit 024c59efc33fb7f01c3f4a195956dcc5fc3507b5  
>     MANTA-3674 manta-adm should have a channel guard
>     
>     commit b71fa427a1d19d5e2537d412f5474b43b4569cf7  
>     MANTA-2769 manta-init should be channel aware

##### @KodyKantor commented at 2019-10-03T15:20:40

> Patch Set 5:
> 
> (7 comments)
> 
> I think this looks really good. Well done!
> 
> ###### cmd/manta-adm.js#881  
> 
> I prefer the 'return' to be on a separate line. This repo is inconsistent about this sort of thing though so it's not a big deal.
> 
> ###### cmd/manta-adm.js#881  
> 
> No problem, I'll fix that.
> 
> ###### cmd/manta-adm.js#970  
> 
> Should these be spaces (based on the previous two flags)?
> 
> ###### cmd/manta-adm.js#970  
> 
> Yep, thanks
> 
> ###### cmd/manta-adm.js#973  
> 
> Are we missing a comma in this string? It reads a little funny to me.
> 
> ###### cmd/manta-adm.js#973  
> 
> ugh, yes that's terrible - I'll reword.
> 
> ###### cmd/manta-init.js#430  
> 
> Since the default value for ARGV.branch is already '', what do you think about removing this condition?
> 
> I like the ability to not search on a specific channel, but having a dual-purpose bool/string flag feels a little weird to me. Maybe we can limit that behavior to just the -C flag by eliminating the similar behavior here for -B?

##### @timfoster commented at 2019-10-03T16:22:41

> Patch Set 5:
> 
> (7 comments)
> 
> Thanks for the review! I'll post the follow-up changes if you can suggest the best approach for lib/adm.js line 4158 (I'm totally easy, either way)
> 
> ###### cmd/manta-init.js#430  
> 
> That's reasonable. Fwiw, earlier versions of this code had our default for -B the same as the current code, 'master', but Trent persuaded me out of doing that, hence this proposed change, but I've tested that the default of '' really does give us a string rather than a boolean, so we're cool.
> 
> ###### lib/adm.js#4158  
> 
> Is there an extra tab here?
> 
> ###### lib/adm.js#4158  
> 
> Yeah, I wasn't sure how to indent this code.
> 
> For editors where 1 tab == 4 spaces, indenting the 2nd and 3rd clauses of the for-loop by only 4 spaces will result in those lines appearing to start on the same column as the body of the loop.
> 
> So instead, I added an extra tab indent so that it was clear
> what was going on. I don't mind removing that extra indent if you prefer? So we have this:
> 
>     for (var i = 0;
>             i < this.ma_plan[svcname][cnid].length;
>             i++) {
>         content;
>         of;
>         loop;
>     }
> 
> rather than
> 
>     for (var i = 0;
>         i < this.ma_plan[svcname][cnid].length;
>         i++) {
>         content;
>         of;
>         loop;
>     }
> 
> I'm easy either way?
> 
> ###### lib/adm.js#4158  
> 
> I would prefer that this is converted into four spaces since it's a line continuation. When 'for' statements wrap lines sometimes people add an extra blank line before the loop body to differentiate the content a bit.
> 
> I agree that our mix tab and space style can be really frustrating.
> 
> ###### lib/adm.js#4158  
> 
> No problem, will do!
> 
> ###### lib/adm.js#4179  
> 
> Perhaps we need a tab here.
> 
> ###### lib/adm.js#4179  
> 
> yep, thanks!

##### @KodyKantor commented at 2019-10-04T14:23:38

> Patch Set 5:
> 
> (2 comments)
> 
> ###### lib/adm.js#4189  
> 
> Should this also be spaces, like the next line?
> 
> ###### lib/adm.js#4189  
> 
> Ugh, thanks - I'm basically just doing what jsstyle/jsl wants me to at this point. Solaris ON-style mixed-tab/space indents are nuts imho :-)

##### @timfoster commented at 2019-10-04T15:06:58

> Patch Set 6:
> 
> New commits:  
>     commit ed19d3ea2a951c0ae06534379d38e037d7ec2e17  
>     address kkantor's review feedback

##### @timfoster commented at 2019-10-04T15:07:15

> Patch Set 5:
> 
> (2 comments)
> 
> I've addressed these changes in patchset 6
> 
> ###### lib/adm.js#4189  
> 
> Yeah, I generally agree with your assessment of the style. Javascript's tendencies for very long lines doesn't help. Does jsstyle complain if these are spaces instead of tabs?
> 
> ###### lib/adm.js#4189  
> 
> nope, jsstyle is fine here

##### @KodyKantor commented at 2019-10-04T15:09:38

> Patch Set 6: Code-Review+1
### comments copied from PR 6