### PR TITLE
MANTA-4744 'manta-adm update' should guard image usage by image.name

### DIFF
--- a/cmd/manta-adm.js
+++ b/cmd/manta-adm.js
@@ -858,14 +858,6 @@ MantaAdm.prototype.do_update = function (subcmd, opts, args, callback)
 		return;
 	}
 
-	if (opts.skip_verify_remote && !opts.skip_verify_channel) {
-		callback(new Error(
-		    'Channel verification requires remote imgapi lookups. ' +
-		    'Use --skip_verify_channel as well as ' +
-		    '--skip-verify-remote.'));
-		return;
-	}
-
 	filename = args[0];
 	if (args.length == 2)
 		service = args[1];
@@ -900,8 +892,7 @@ MantaAdm.prototype.do_update = function (subcmd, opts, args, callback)
 		},
 		function verifyPlan(_, stepcb) {
 			adm.verifyPlan({
-				skip_verify_channel: opts.skip_verify_channel,
-				skip_verify_remote: opts.skip_verify_remote
+				skip_verify_channel: opts.skip_verify_channel
 			}, stepcb);
 		},
 		function dumpPlan(_, stepcb) {
@@ -975,14 +966,6 @@ MantaAdm.prototype.do_update.options = [
     'names': [ 'experimental', 'X' ],
     'type':  'bool',
     'help': 'Allow deployment of experimental services'
-},
-{
-	'names': [ 'skip-verify-remote' ],
-	'type': 'bool',
-	'help': 'When provisioning an image, avoid doing any lookups against ' +
-	'the remote update imgapi instance for this datacenter. ' +
-	'Requires --skip-verify-channel',
-	'default': false
 },
 {
     'names': [ 'skip-verify-channel' ],

--- a/cmd/manta-adm.js
+++ b/cmd/manta-adm.js
@@ -891,9 +891,10 @@ MantaAdm.prototype.do_update = function (subcmd, opts, args, callback)
 			}, stepcb);
 		},
 		function verifyPlan(_, stepcb) {
-			adm.verifyPlan(
-			    {skip_verify_channel: opts.skip_verify_channel},
-			    stepcb);
+			adm.verifyPlan({
+				skip_verify_channel: opts.skip_verify_channel,
+				skip_verify_remote: opts.skip_verify_remote
+			}, stepcb);
 		},
 		function dumpPlan(_, stepcb) {
 			adm.execPlan(process.stdout, process.stderr,
@@ -966,6 +967,13 @@ MantaAdm.prototype.do_update.options = [
     'names': [ 'experimental', 'X' ],
     'type':  'bool',
     'help': 'Allow deployment of experimental services'
+},
+{
+	'names': [ 'skip-verify-remote' ],
+	'type': 'bool',
+	'help': 'When provisioning an image, avoid doing any lookups against ' +
+	'the remote update imgapi instance for this datacenter',
+	'default': false
 },
 {
     'names': [ 'skip-verify-channel' ],

--- a/cmd/manta-adm.js
+++ b/cmd/manta-adm.js
@@ -858,6 +858,14 @@ MantaAdm.prototype.do_update = function (subcmd, opts, args, callback)
 		return;
 	}
 
+	if (opts.skip_verify_remote && !opts.skip_verify_channel) {
+		callback(new Error(
+		    'Channel verification requires remote imgapi lookups. ' +
+		    'Use --skip_verify_channel as well as ' +
+		    '--skip-verify-remote.'));
+		return;
+	}
+
 	filename = args[0];
 	if (args.length == 2)
 		service = args[1];
@@ -972,7 +980,8 @@ MantaAdm.prototype.do_update.options = [
 	'names': [ 'skip-verify-remote' ],
 	'type': 'bool',
 	'help': 'When provisioning an image, avoid doing any lookups against ' +
-	'the remote update imgapi instance for this datacenter',
+	'the remote update imgapi instance for this datacenter. ' +
+	'Requires --skip-verify-channel',
 	'default': false
 },
 {

--- a/docs/man/man1/manta-adm.md
+++ b/docs/man/man1/manta-adm.md
@@ -794,8 +794,8 @@ options described above, plus:
   When upgrading a zone, always provision a new zone and deprovision the
   previous one, rather than reprovisioning the existing one.
 
-`--skip-verify-channel`
-  When upgrading, do perform any lookups on the "remote" (usually https://updates.joyent.com)
+`--skip-verify-remote`
+  When upgrading, do not perform any lookups on the "remote" (usually https://updates.joyent.com)
   imgapi channel that was set on the headnode using the `sdcadm channel`
   command. Typically, this option would be used when operating a Triton instance
   that is not connected to the internet.

--- a/docs/man/man1/manta-adm.md
+++ b/docs/man/man1/manta-adm.md
@@ -20,7 +20,7 @@ manta-adm - administer a Manta deployment
 
 `manta-adm show [-l LOG_FILE] [-js] SERVICE`
 
-`manta-adm update [-l LOG_FILE] [-n] [-y] [--no-reprovision] [--skip-verify-channel] FILE [SERVICE]`
+`manta-adm update [-l LOG_FILE] [-n] [-y] [--no-reprovision] [--skip-verify-remote] [--skip-verify-channel] FILE [SERVICE]`
 
 `manta-adm zk list [-l LOG_FILE] [-H] [-o FIELD...]`
 
@@ -764,7 +764,7 @@ Example: show only postgres zones in the current datacenter
 
 ### "update" subcommand
 
-`manta-adm update [-l LOG_FILE] [-n] [-y] [--no-reprovision] FILE [SERVICE]`
+`manta-adm update [-l LOG_FILE] [-n] [-y] [--no-reprovision] [--skip-verify-remote] [--skip-verify-channel] FILE [SERVICE]`
 
 The `manta-adm update` command updates a Manta deployment to match the JSON
 configuration stored at path `FILE`.  The JSON configuration describes the
@@ -793,6 +793,12 @@ options described above, plus:
 `--no-reprovision`
   When upgrading a zone, always provision a new zone and deprovision the
   previous one, rather than reprovisioning the existing one.
+
+`--skip-verify-channel`
+  When upgrading, do perform any lookups on the "remote" (usually https://updates.joyent.com)
+  imgapi channel that was set on the headnode using the `sdcadm channel`
+  command. Typically, this option would be used when operating a Triton instance
+  that is not connected to the internet.
 
 `--skip-verify-channel`
   When upgrading, do not verify that the images being provisioned or

--- a/docs/man/man1/manta-adm.md
+++ b/docs/man/man1/manta-adm.md
@@ -764,7 +764,7 @@ Example: show only postgres zones in the current datacenter
 
 ### "update" subcommand
 
-`manta-adm update [-l LOG_FILE] [-n] [-y] [--no-reprovision] [--skip-verify-remote] [--skip-verify-channel] FILE [SERVICE]`
+`manta-adm update [-l LOG_FILE] [-n] [-y] [--no-reprovision] [--skip-verify-channel] FILE [SERVICE]`
 
 The `manta-adm update` command updates a Manta deployment to match the JSON
 configuration stored at path `FILE`.  The JSON configuration describes the
@@ -793,12 +793,6 @@ options described above, plus:
 `--no-reprovision`
   When upgrading a zone, always provision a new zone and deprovision the
   previous one, rather than reprovisioning the existing one.
-
-`--skip-verify-remote`
-  When upgrading, do not perform any lookups on the "remote" (usually https://updates.joyent.com)
-  imgapi channel that was set on the headnode using the `sdcadm channel`
-  command. Typically, this option would be used when operating a Triton instance
-  that is not connected to the internet.
 
 `--skip-verify-channel`
   When upgrading, do not verify that the images being provisioned or

--- a/docs/man/man1/manta-adm.md
+++ b/docs/man/man1/manta-adm.md
@@ -20,7 +20,7 @@ manta-adm - administer a Manta deployment
 
 `manta-adm show [-l LOG_FILE] [-js] SERVICE`
 
-`manta-adm update [-l LOG_FILE] [-n] [-y] [--no-reprovision] [--skip-verify-remote] [--skip-verify-channel] FILE [SERVICE]`
+`manta-adm update [-l LOG_FILE] [-n] [-y] [--no-reprovision] [--skip-verify-channel] FILE [SERVICE]`
 
 `manta-adm zk list [-l LOG_FILE] [-H] [-o FIELD...]`
 

--- a/lib/adm.js
+++ b/lib/adm.js
@@ -4157,7 +4157,15 @@ function fetchLocalImages(opts, cb) {
 				    opts.services_by_image[imageUuid]);
 				opts.log.debug(
 				    'missing local image ' + missing);
-				nextImage();
+				if (err.restCode === 'ResourceNotFound') {
+					// 404s are fine, anything else is not.
+					nextImage();
+				} else {
+					opts.log.error(
+					    'error getting image %s: %s',
+					     imageUuid, err);
+					nextImage(err);
+				}
 			} else {
 				opts.local_images[imageUuid] = image;
 				nextImage();
@@ -4239,7 +4247,15 @@ function fetchRemoteImages(opts, cb) {
 				    opts.services_by_image[imageUuid]);
 				opts.log.debug(
 				    'missing remote image ' + missing);
-				nextImage();
+				if (err.restCode === 'ResourceNotFound') {
+					// 404s are fine, anything else is not.
+					nextImage();
+				} else {
+					opts.log.error(
+					    'error getting image %s: %s',
+					     imageUuid, err);
+					nextImage(err);
+				}
 			} else {
 				opts.remote_images[imageUuid] = image;
 				nextImage();
@@ -4248,7 +4264,7 @@ function fetchRemoteImages(opts, cb) {
 		}
 	}, function finishFetchRemoteImages(err) {
 		if (err) {
-			opts.log.debug('error getting remote images %d', err);
+			opts.log.error('error getting remote images %d', err);
 			cb(err);
 		} else {
 			cb();
@@ -4351,8 +4367,7 @@ maAdm.prototype.verifyPlan = function (opts, cb)
 	    remote_imgapi: self.ma_sdc.REMOTE_IMGAPI,
 	    services_by_image: services_by_image,
 	    channel: self.ma_channel,
-	    skip_verify_channel: opts.skip_verify_channel,
-	    skip_verify_remote: opts.skip_verify_remote
+	    skip_verify_channel: opts.skip_verify_channel
 	};
 
 	// retrieve local and (optionally) remote Image objects in order to

--- a/lib/adm.js
+++ b/lib/adm.js
@@ -4183,6 +4183,7 @@ function fetchRemoteImages(opts, cb) {
 	assertplus.object(opts.services_by_image, 'opts.services_by_image');
 	assertplus.object(opts.log, 'opts.log');
 	assertplus.object(opts.remote_imgapi, 'opts.remote_imgapi');
+	assertplus.object(opts.local_images, 'opts.local_images');
 	assertplus.bool(opts.skip_verify_remote, 'opts.skip_verify_remote');
 	assertplus.ok(opts.channel !== undefined);
 	assertplus.func(cb, 'cb');
@@ -4207,8 +4208,31 @@ function fetchRemoteImages(opts, cb) {
 		imgapi_opts.channel = opts.channel;
 	}
 
+	// By default, search for all images in the remote imgapi, since
+	// channel information is only stored there.
+	var uuids = Object.keys(opts.services_by_image);
+
+	// If we're skipping channel verification, then we only need remote
+	// images that don't already exist locally in order to do the
+	// image name check.
+	if (opts.skip_verify_channel) {
+		uuids = [];
+		var local_uuids = Object.keys(opts.local_images);
+		uuids = Object.keys(opts.services_by_image).filter(
+			function (uuid) {
+				if (local_uuids.indexOf(uuid) === -1) {
+					return (true);
+				} else {
+					opts.log.debug(
+					    'not searching remote imgapi ' +
+					    'for %s, it exists locally', uuid);
+					return (false);
+				}
+		});
+	}
+
 	vasync.forEachParallel({
-		inputs: Object.keys(opts.services_by_image),
+		inputs: uuids,
 		func: function fetchOneImage(imageUuid, nextImage) {
 		opts.log.debug(
 				'getting remote image %s for service %s on ' +
@@ -4406,8 +4430,7 @@ maAdm.prototype.verifyPlan = function (opts, cb)
 				    'The following images were not found on ' +
 				    'the default updates channel and ' +
 				    'cannot be provisioned. ' +
-					'(Use --skip-verify-channel or ' +
-					'--skip-verify-remote to ' +
+					'(Use --skip-verify-channel to ' +
 				    'override):\n    %s',
 				    imagesNotInTheChannel.join('\n    ')));
 			} else {
@@ -4415,8 +4438,7 @@ maAdm.prototype.verifyPlan = function (opts, cb)
 				    'The following images were not found on ' +
 				    'the "%s" channel and cannot be ' +
 				    'provisioned. ' +
-					'(Use --skip-verify-channel or ' +
-					'--skip-verify-remote to ' +
+					'(Use --skip-verify-channel to ' +
 				    'override):\n    %s',
 				    self.ma_channel,
 				    imagesNotInTheChannel.join('\n    ')));

--- a/lib/adm.js
+++ b/lib/adm.js
@@ -4287,12 +4287,12 @@ function fetchImages(opts, cb) {
  *    moray zone with anything other than a moray image.
  *
  * 3. All images for deployment exist in the local imgapi instance in this
- *    datacenter
+ *    datacenter.
  *
  *  Options:
- * * - skip_verify_channel: if true, we avoid verifying that each image to be
+ * - skip_verify_channel: if true, we avoid verifying that each image to be
  *   provisioned is present on the defined SDC updates.joyent.com channel.
- * * - skip_verify_remote: if true, we avoid doing any remote IMGAPI lookups,
+ * - skip_verify_remote: if true, we avoid doing any remote IMGAPI lookups,
  *   specifically for cases where we have a Triton instance that is not
  *   connected to an external network.
  */

--- a/lib/adm.js
+++ b/lib/adm.js
@@ -4128,15 +4128,173 @@ maAdm.prototype.generatePlan = function (opts, callback)
 };
 
 /*
+ * Retrieves Image objects, specified by the uuid keys of the
+ * 'services_by_image' parameter, setting the results in opts.local_images.
+ */
+function fetchLocalImages(opts, cb) {
+	assertplus.object(opts, 'opts');
+	assertplus.object(opts.services_by_image, 'opts.services_by_image');
+	assertplus.object(opts.log, 'opts.log');
+	assertplus.object(opts.local_imgapi, 'opts.local_imgapi');
+	assertplus.func(cb, 'cb');
+
+	opts.local_images = {};
+
+	var imgapi_opts = {};
+	vasync.forEachParallel({
+	    inputs: Object.keys(opts.services_by_image),
+	    func: function getOneImageName(imageUuid, nextImage) {
+		opts.log.debug(
+			    'getting local image %s for service %s',
+			    imageUuid, opts.services_by_image[imageUuid]);
+		opts.local_imgapi.getImage(imageUuid, imgapi_opts,
+			function getImage(err, image) {
+			if (err) {
+				// At this point, missing images are not fatal
+				// unless we're doing local-only lookup, but
+				// deal with that elsewhere.
+				var missing = sprintf('%s (%s)', imageUuid,
+				    opts.services_by_image[imageUuid]);
+				opts.log.debug(
+				    'missing local image ' + missing);
+				nextImage();
+			} else {
+				opts.local_images[imageUuid] = image;
+				nextImage();
+			}
+		});
+		}
+	}, function finishFetchLocalImages(err) {
+		if (err) {
+			opts.log.debug('error getting local images %s', err);
+			cb(err);
+		} else {
+			cb();
+		}
+	});
+}
+
+/*
+ * Retrieves Image objects, specified by the uuid keys of the
+ * 'services_by_image' parameter, setting the results in opts.remote_images.
+ */
+function fetchRemoteImages(opts, cb) {
+	assertplus.object(opts, 'opts');
+	assertplus.object(opts.services_by_image, 'opts.services_by_image');
+	assertplus.object(opts.log, 'opts.log');
+	assertplus.object(opts.remote_imgapi, 'opts.remote_imgapi');
+	assertplus.bool(opts.skip_verify_remote, 'opts.skip_verify_remote');
+	assertplus.ok(opts.channel !== undefined);
+	assertplus.func(cb, 'cb');
+
+	opts.remote_images = {};
+
+	if (opts.skip_verify_remote) {
+		opts.log.debug('skipping lookup of remote images');
+		cb();
+		return;
+	}
+
+	/*
+	 * The channel can be null when e.g. 'sdcadm channel unset' causes our
+	 * SAPI entry to have that metadata removed. In that case, when
+	 * searching for images, we look in the default channel as configured on
+	 * the updates imgapi server itself.
+	 */
+
+	var imgapi_opts = {};
+	if (opts.channel !== null) {
+		imgapi_opts.channel = opts.channel;
+	}
+
+	vasync.forEachParallel({
+		inputs: Object.keys(opts.services_by_image),
+		func: function fetchOneImage(imageUuid, nextImage) {
+		opts.log.debug(
+				'getting remote image %s for service %s on ' +
+				'channel %s',
+				imageUuid, opts.services_by_image[imageUuid],
+				opts.channel);
+		opts.remote_imgapi.getImage(imageUuid, imgapi_opts,
+			function getImage(err, image) {
+			if (err) {
+				var missing = sprintf('%s (%s)', imageUuid,
+				    opts.services_by_image[imageUuid]);
+				opts.log.debug(
+				    'missing remote image ' + missing);
+				nextImage();
+			} else {
+				opts.remote_images[imageUuid] = image;
+				nextImage();
+			}
+		});
+		}
+	}, function finishFetchRemoteImages(err) {
+		if (err) {
+			opts.log.debug('error getting remote images %d', err);
+			cb(err);
+		} else {
+			cb();
+		}
+	});
+}
+
+/*
+ * Retrieves Image objects, invoking fetchLocalImages and fetchRemoteImages.
+ * Missing images are not considered errors at this point.
+ */
+function fetchImages(opts, cb) {
+	assertplus.object(opts, 'opts');
+	assertplus.func(cb, 'cb');
+	assertplus.object(opts.services_by_image, 'opts.services_by_image');
+	assertplus.object(opts.remote_imgapi, 'opts.remote_imgapi');
+	assertplus.object(opts.local_imgapi, 'opts.local_imgapi');
+	assertplus.bool(opts.skip_verify_remote, 'opts.skip_verify_remote');
+
+	vasync.pipeline({
+		arg: opts,
+		funcs: [
+			function stepFetchLocalImages(arg, stepcb) {
+				fetchLocalImages(arg, stepcb);
+			},
+			// even if we've got local images, we'll still need the
+			// remote ones in order to verify the channel
+			function stepFetchRemoteImages(arg, stepcb) {
+				fetchRemoteImages(arg, stepcb);
+			}
+		]
+	}, function cbImagesLists(err) {
+		if (err) {
+			cb(err);
+			return;
+		} else {
+			cb(null, opts.local_images, opts.remote_images);
+		}
+	});
+}
+
+/*
  * Determine whether the plan that was generated adheres to any restrictions
  * that are in place.
- * For now the only check implemented is to ensure that all images for
- * deployment are available on the specific imgapi channel set by
- * 'sdcadm channel set' on the 'remote_imgapi' set in etc/config.json.
  *
- * Options:
- * - skip_verify_channel: if true, we avoid verifying that each image to be
+ * We check the following restrictions:
+ *
+ * 1. All images for deployment are available on the specific imgapi channel
+ *    set by 'sdcadm channel set' on the 'remote_imgapi' set in etc/config.json.
+ *
+ * 2. All images for deployment have image names that match the service they're
+ *    being deployed for. It would be bad if were to able to reprovision a
+ *    moray zone with anything other than a moray image.
+ *
+ * 3. All images for deployment exist in the local imgapi instance in this
+ *    datacenter
+ *
+ *  Options:
+ * * - skip_verify_channel: if true, we avoid verifying that each image to be
  *   provisioned is present on the defined SDC updates.joyent.com channel.
+ * * - skip_verify_remote: if true, we avoid doing any remote IMGAPI lookups,
+ *   specifically for cases where we have a Triton instance that is not
+ *   connected to an external network.
  */
 maAdm.prototype.verifyPlan = function (opts, cb)
 {
@@ -4144,17 +4302,13 @@ maAdm.prototype.verifyPlan = function (opts, cb)
 	assertplus.object(opts, 'opts');
 	assertplus.func(cb, 'cb');
 	assertplus.bool(opts.skip_verify_channel, 'opts.skip_verify_channel');
+	assertplus.bool(opts.skip_verify_remote, 'opts.skip_verify_remote');
 
 	var self = this;
 
-	if (opts.skip_verify_channel) {
-		return (cb());
-	}
 	/*
-	 * If we're doing channel verification, go through our plan,
-	 * checking that each new image exists on that channel. To do this,
-	 * find the set of new image uuids per-service across all compute nodes
-	 * in the plan.
+	 * Go through our plan to find the set of new image uuids per-service
+	 * across all compute nodes in the plan.
 	 */
 	// We don't have a Set() object, so instead use unique Object keys
 	var services_by_image = {};
@@ -4177,68 +4331,112 @@ maAdm.prototype.verifyPlan = function (opts, cb)
 		}
 	}
 
-	var imgapi_opts = {};
-	/*
-	 * The channel can be null when e.g. 'sdcadm channel unset' causes our
-	 * SAPI entry to have that metadata removed. In that case, when
-	 * searching for images, we look in the default channel as configured on
-	 * the updates imgapi server itself.
-	 */
-	if (self.ma_channel !== null) {
-		imgapi_opts.channel = self.ma_channel;
-	}
+	var fetch_images_opts = {
+	    log: self.ma_log,
+	    local_imgapi: self.ma_sdc.IMGAPI,
+	    remote_imgapi: self.ma_sdc.REMOTE_IMGAPI,
+	    services_by_image: services_by_image,
+	    channel: self.ma_channel,
+	    skip_verify_channel: opts.skip_verify_channel,
+	    skip_verify_remote: opts.skip_verify_remote
+	};
 
-	// An array of strings, later used to form an error message.
-	var imagesNotInTheChannel = [];
-	// process each of the images in parallel
-	vasync.forEachParallel({
-	    inputs: Object.keys(services_by_image),
-	    func: function channelCheckOneImage(imageUuid, nextImage) {
-		self.ma_log.debug(
-			    'looking up image %s for service %s on ' +
-			    'channel %s',
-			    imageUuid, services_by_image[imageUuid],
-			    self.ma_channel);
-		self.ma_sdc.REMOTE_IMGAPI.getImage(imageUuid, imgapi_opts,
-			function getImage(err, image) {
-			if (err) {
-				// note that we don't invoke the err callback
-				// since vasync will then report only
-				// 'the first of n errors'
-				var missing = sprintf('%s (%s)', imageUuid,
-				    services_by_image[imageUuid]);
-				self.ma_log.debug('missing image ' + missing);
-				imagesNotInTheChannel.push(missing);
-				nextImage();
-			} else {
-				nextImage();
-			}
-		});
-		}
-	}, function finish(err) {
+	// retrieve local and (optionally) remote Image objects in order to
+	// verify the plan.
+	fetchImages(fetch_images_opts,
+	    function verifyImages(err, local_images, remote_images) {
 		if (err) {
 			cb(err);
-		} else if (imagesNotInTheChannel.length > 0) {
-			var msg;
+			return;
+		}
+
+		// We don't have a Set() object, instead use unique Object keys
+		var imagesIncorrectNames = {};
+		var imagesNotInTheChannel = [];
+		var missingLocalImages = [];
+
+		var checkUuids = Object.keys(services_by_image);
+		checkUuids.forEach(function checkUuid(uuid) {
+			var svcName = services_by_image[uuid];
+			var imgName = svcs.serviceNameToImageName(svcName);
+			var imgDesc = sprintf(
+			    '%s (%s)', uuid, services_by_image[uuid]);
+			var local_uuids = Object.keys(local_images);
+			var remote_uuids = Object.keys(remote_images);
+
+			if (!opts.skip_verify_remote) {
+				if (remote_uuids.indexOf(uuid) === -1) {
+					if (!opts.skip_verify_channel) {
+						imagesNotInTheChannel.push(
+						    imgDesc);
+					}
+				} else {
+					// There is some amount of duplication
+					// here, in that later, we check the
+					// local image as well. However if the
+					// image isn't present in the local
+					// imgapi, that code may not be invoked.
+					if (remote_images[uuid].name !==
+					    imgName) {
+						imagesIncorrectNames[sprintf(
+						    '%s (%s, not %s)', uuid,
+						    remote_images[uuid].name,
+						    imgName)] = true;
+					}
+				}
+			}
+
+			if (local_uuids.indexOf(uuid) === -1) {
+				missingLocalImages.push(imgDesc);
+			} else {
+				if (local_images[uuid].name !== imgName) {
+					imagesIncorrectNames[sprintf(
+					    '%s (%s, not %s)', uuid,
+					    local_images[uuid].name,
+					    imgName)] = true;
+				}
+			}
+		});
+
+		// Construct an error message
+		var msgs = [];
+		if (imagesNotInTheChannel.length > 0) {
 			if (!self.ma_channel) {
-				msg = sprintf(
+				msgs.push(sprintf(
 				    'The following images were not found on ' +
 				    'the default updates channel and ' +
 				    'cannot be provisioned. ' +
-				    '(Use --skip-verify-channel to ' +
-				    'override): %s',
-				    imagesNotInTheChannel.join(', '));
+					'(Use --skip-verify-channel or ' +
+					'--skip-verify-remote to ' +
+				    'override):\n    %s',
+				    imagesNotInTheChannel.join('\n    ')));
 			} else {
-				msg = sprintf(
+				msgs.push(sprintf(
 				    'The following images were not found on ' +
 				    'the "%s" channel and cannot be ' +
 				    'provisioned. ' +
-				    '(Use --skip-verify-channel to ' +
-				    'override): %s',
+					'(Use --skip-verify-channel or ' +
+					'--skip-verify-remote to ' +
+				    'override):\n    %s',
 				    self.ma_channel,
-				    imagesNotInTheChannel.join(', '));
+				    imagesNotInTheChannel.join('\n    ')));
 			}
-			cb(new VError(msg));
+		}
+		if (Object.keys(imagesIncorrectNames).length > 0) {
+			msgs.push(sprintf(
+			    'The following images do not deliver ' +
+				'the service specified in the manta-adm ' +
+				'update json file:\n    %s',
+			    Object.keys(imagesIncorrectNames).join('\n    ')));
+		}
+		if (missingLocalImages.length > 0) {
+			msgs.push(sprintf(
+			    'The following images are not available in the ' +
+			    'local imgapi instance:\n    %s',
+			    missingLocalImages.join('\n    ')));
+		}
+		if (msgs.length !== 0) {
+			cb(new VError(msgs.join('\n')));
 		} else {
 			cb();
 		}

--- a/lib/adm.js
+++ b/lib/adm.js
@@ -4184,17 +4184,10 @@ function fetchRemoteImages(opts, cb) {
 	assertplus.object(opts.log, 'opts.log');
 	assertplus.object(opts.remote_imgapi, 'opts.remote_imgapi');
 	assertplus.object(opts.local_images, 'opts.local_images');
-	assertplus.bool(opts.skip_verify_remote, 'opts.skip_verify_remote');
 	assertplus.ok(opts.channel !== undefined);
 	assertplus.func(cb, 'cb');
 
 	opts.remote_images = {};
-
-	if (opts.skip_verify_remote) {
-		opts.log.debug('skipping lookup of remote images');
-		cb();
-		return;
-	}
 
 	/*
 	 * The channel can be null when e.g. 'sdcadm channel unset' causes our
@@ -4273,7 +4266,6 @@ function fetchImages(opts, cb) {
 	assertplus.object(opts.services_by_image, 'opts.services_by_image');
 	assertplus.object(opts.remote_imgapi, 'opts.remote_imgapi');
 	assertplus.object(opts.local_imgapi, 'opts.local_imgapi');
-	assertplus.bool(opts.skip_verify_remote, 'opts.skip_verify_remote');
 
 	vasync.pipeline({
 		arg: opts,
@@ -4316,9 +4308,8 @@ function fetchImages(opts, cb) {
  *  Options:
  * - skip_verify_channel: if true, we avoid verifying that each image to be
  *   provisioned is present on the defined SDC updates.joyent.com channel.
- * - skip_verify_remote: if true, we avoid doing any remote IMGAPI lookups,
- *   specifically for cases where we have a Triton instance that is not
- *   connected to an external network.
+ *   This will still mean we do a remote lookup for any images that aren't
+ *   present on the local imgapi in order to test for item 2 above.
  */
 maAdm.prototype.verifyPlan = function (opts, cb)
 {
@@ -4326,7 +4317,6 @@ maAdm.prototype.verifyPlan = function (opts, cb)
 	assertplus.object(opts, 'opts');
 	assertplus.func(cb, 'cb');
 	assertplus.bool(opts.skip_verify_channel, 'opts.skip_verify_channel');
-	assertplus.bool(opts.skip_verify_remote, 'opts.skip_verify_remote');
 
 	var self = this;
 
@@ -4388,25 +4378,20 @@ maAdm.prototype.verifyPlan = function (opts, cb)
 			var local_uuids = Object.keys(local_images);
 			var remote_uuids = Object.keys(remote_images);
 
-			if (!opts.skip_verify_remote) {
-				if (remote_uuids.indexOf(uuid) === -1) {
-					if (!opts.skip_verify_channel) {
-						imagesNotInTheChannel.push(
-						    imgDesc);
-					}
-				} else {
-					// There is some amount of duplication
-					// here, in that later, we check the
-					// local image as well. However if the
-					// image isn't present in the local
-					// imgapi, that code may not be invoked.
-					if (remote_images[uuid].name !==
-					    imgName) {
-						imagesIncorrectNames[sprintf(
-						    '%s (%s, not %s)', uuid,
-						    remote_images[uuid].name,
-						    imgName)] = true;
-					}
+			if (remote_uuids.indexOf(uuid) === -1) {
+				if (!opts.skip_verify_channel) {
+					imagesNotInTheChannel.push(imgDesc);
+				}
+			} else {
+				// There is some amount of duplication here, in
+				// that later, we check the local image as well.
+				// However if the image isn't present in the
+				// local imgapi, that code may not be invoked.
+				if (remote_images[uuid].name !== imgName) {
+					imagesIncorrectNames[
+					    sprintf('%s (%s, not %s)', uuid,
+					        remote_images[uuid].name,
+					        imgName)] = true;
 				}
 			}
 


### PR DESCRIPTION
This adds a guard that checks that the services.js image name mapping for a service matches the image.name of the Image to be provisioned.

While we were in the area, we added a check that the Image exists in the local imgapi (rather than eventually blowing up later during provisioning if the image is missing) and allow a --skip-verify-remote flag for Triton instances that are not connected to a network capable of reaching https://updates.joyent.com
