### PR TITLE
MANTA-4842 manta-adm channel guard SAPI search must not use include_master=true

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -956,8 +956,7 @@ function getSdcChannel(opts, cb) {
 	var log = opts.log;
 
 	var search = {
-		name: 'sdc',
-		include_master: true
+		name: 'sdc'
 	};
 
 	sapi.listApplications(search, function (err, apps) {


### PR DESCRIPTION
This is the master change for the manta-adm channel guard fix. Testing notes are in the jira ticket.