### PR TITLE
MANTA-4809 protect against accidental manta-init changing between mantav1 and mantav2

### DIFF
--- a/cmd/manta-init.js
+++ b/cmd/manta-init.js
@@ -46,7 +46,7 @@ var POSEIDON_PASSWORD = 'trident123';
 
 
 // This manta-init can *only* create mantav2 applications.
-var MANTA_VERSION = 2;
+var MANTAV = 2;
 
 /*
  * If the -c option isn't specified, the default is to download 10 images in
@@ -637,12 +637,12 @@ var pipelineFuncs = [
 
 	function checkMantaApplicationVersion(_, cb) {
 		if (self.manta_app &&
-		    self.manta_app.metadata['MANTAV'] !== MANTA_VERSION) {
+		    self.manta_app.metadata['MANTAV'] !== MANTAV) {
 			return cb(new VError(
 			    'A v%s Manta application was found on this ' +
 			    'Triton instance which conflicts with the ' +
 			    'version being deployed. ' +
-			    'You must delete that application before ' +
+			    'You must resolve that problem before ' +
 			    'attempting to deploy a new Manta application.',
 			    self.manta_app.metadata['MANTAV']));
 		}
@@ -663,7 +663,7 @@ var pipelineFuncs = [
 			metadata: {
 				// This authoritatively indicates that this is a
 				// mantav2 deployment.
-				MANTAV: MANTA_VERSION
+				MANTAV: MANTAV
 			}
 		};
 

--- a/cmd/manta-init.js
+++ b/cmd/manta-init.js
@@ -44,6 +44,10 @@ var POSEIDON;
 var POSEIDON_LOGIN = 'poseidon';
 var POSEIDON_PASSWORD = 'trident123';
 
+
+// This manta-init can *only* create mantav2 applications.
+var MANTA_VERSION = 2;
+
 /*
  * If the -c option isn't specified, the default is to download 10 images in
  * parallel.
@@ -631,6 +635,20 @@ var pipelineFuncs = [
 		});
 	},
 
+	function checkMantaApplicationVersion(_, cb) {
+		if (self.manta_app &&
+		    self.manta_app.metadata['MANTAV'] !== MANTA_VERSION) {
+			return cb(new VError(
+			    'A v%s Manta application was found on this ' +
+			    'Triton instance which conflicts with the ' +
+			    'version being deployed. ' +
+			    'You must delete that application before ' +
+			    'attempting to deploy a new Manta application.',
+			    self.manta_app.metadata['MANTAV']));
+		}
+		return (cb(null));
+	},
+
 	function createMantaApplication(_, cb) {
 		var log = self.log;
 		var sapi = self.SAPI;
@@ -645,7 +663,7 @@ var pipelineFuncs = [
 			metadata: {
 				// This authoritatively indicates that this is a
 				// mantav2 deployment.
-				MANTAV: 2
+				MANTAV: MANTA_VERSION
 			}
 		};
 


### PR DESCRIPTION
I'm happy to wordsmith the error message here. I assume we also want this check on the v1 branch - if so, I'll backport this once we're happy with the messaging.