### PR TITLE
MANTA-4861 manta-adm should have a -C option to override the channel

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # sdc-manta changelog
 
+# 1.4.0
+
+- MANTA-4861 manta-adm should have a -C option to override the channel
+
 # 1.3.1
 
 - MANTA-4920 fix and doc Manta service deployment ordering (#45)

--- a/cmd/manta-adm.js
+++ b/cmd/manta-adm.js
@@ -7,7 +7,7 @@
  */
 
 /*
- * Copyright 2019 Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  */
 
 /*
@@ -760,6 +760,15 @@ MantaAdm.prototype.do_update = function(_subcmd, opts, args, callback) {
         return;
     }
 
+    if (opts.channel && opts.skip_verify_channel) {
+        callback(
+            new Error(
+                '-C and --skip-verify-channel cannot be used ' +
+                    'at the same time'
+            )
+        );
+    }
+
     filename = args[0];
     if (args.length === 2) {
         service = args[1];
@@ -782,6 +791,10 @@ MantaAdm.prototype.do_update = function(_subcmd, opts, args, callback) {
                 },
                 function determineDefaultChannel(_, stepcb) {
                     if (opts.skip_verify_channel) {
+                        stepcb();
+                        return;
+                    } else if (opts.channel) {
+                        adm.ma_channel = opts.channel;
                         stepcb();
                         return;
                     }
@@ -874,6 +887,14 @@ MantaAdm.prototype.do_update.options = [
     maCommonOptions.logFile,
     maCommonOptions.dryrun,
     maCommonOptions.confirm,
+    {
+        names: ['channel', 'C'],
+        type: 'string',
+        help:
+            'When provisioning an image, verify that the image ' +
+            'comes from this update channel. The default is to use the ' +
+            'update channel set for this datacenter.'
+    },
     {
         names: ['no-reprovision'],
         type: 'bool',

--- a/docs/man/man1/manta-adm.md
+++ b/docs/man/man1/manta-adm.md
@@ -1,4 +1,4 @@
-# MANTA-ADM 1 "2019" Manta "Manta Operator Commands"
+# MANTA-ADM 1 "2020" Manta "Manta Operator Commands"
 
 ## NAME
 
@@ -715,7 +715,7 @@ Example: show only postgres zones in the current datacenter
 
 ### "update" subcommand
 
-`manta-adm update [-l LOG_FILE] [-n] [-y] [--no-reprovision] [--skip-verify-channel] FILE [SERVICE]`
+`manta-adm update [-l LOG_FILE] [-n] [-y] [-C CHANNEL] [--no-reprovision] [--skip-verify-channel] FILE [SERVICE]`
 
 The `manta-adm update` command updates a Manta deployment to match the JSON
 configuration stored at path `FILE`.  The JSON configuration describes the
@@ -741,15 +741,19 @@ upgrading all components.**
 This command supports the `-l/--log_file`, `-n/--dryrun`, and `-y/--confirm`
 options described above, plus:
 
+`-C CHANNEL, --channel CHANNEL`
+  When upgrading, verify that the images being provisioned or reprovisioned
+  are present on the "remote" (usually https://updates.joyent.com) imgapi
+  channel passed as the `CHANNEL` argument. The default is to use the imgapi
+  channel that was set on the headnode using the `sdcadm channel` command.
+
 `--no-reprovision`
   When upgrading a zone, always provision a new zone and deprovision the
   previous one, rather than reprovisioning the existing one.
 
 `--skip-verify-channel`
-  When upgrading, do not verify that the images being provisioned or
-  reprovisioned are present on the "remote" (usually https://updates.joyent.com)
-  imgapi channel that was set on the headnode using the `sdcadm channel`
-  command.
+  When upgrading, do not verify that images being provisioned or reprovisioned
+  come from any particular channel.
 
 If `SERVICE` is specified, then only instances of the named service are
 changed.
@@ -861,7 +865,7 @@ and `-y/--confirm` options described above.
 
 ## COPYRIGHT
 
-Copyright 2019 Joyent, Inc.
+Copyright 2020 Joyent, Inc.
 
 ## SEE ALSO
 

--- a/lib/adm.js
+++ b/lib/adm.js
@@ -7,7 +7,7 @@
  */
 
 /*
- * Copyright 2019 Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  */
 
 /*
@@ -4679,7 +4679,8 @@ function fetchImages(opts, cb) {
  * We check the following restrictions:
  *
  * 1. All images for deployment are available on the specific imgapi channel
- *    set by 'sdcadm channel set' on the 'remote_imgapi' set in etc/config.json.
+ *    set by 'sdcadm channel set' on the 'remote_imgapi' set in etc/config.json
+ *    or the channel passed by the -C argument to manta-adm.
  *
  * 2. All images for deployment have image names that match the service they're
  *    being deployed for. It would be bad if were to able to reprovision a
@@ -4690,7 +4691,8 @@ function fetchImages(opts, cb) {
  *
  *  Options:
  * - skip_verify_channel: if true, we avoid verifying that each image to be
- *   provisioned is present on the defined SDC updates.joyent.com channel.
+ *   provisioned is present on the defined SDC updates.joyent.com channel
+ *   or channel passed by the -C argument.
  *   This will still mean we do a remote lookup for any images that aren't
  *   present on the local imgapi in order to test for item 2 above.
  */
@@ -4804,7 +4806,9 @@ maAdm.prototype.verifyPlan = function(opts, cb) {
                             'the default updates channel and ' +
                             'cannot be provisioned. ' +
                             '(Use --skip-verify-channel to ' +
-                            'override):\n    %s',
+                            'override, -C to specify a different ' +
+                            "channel or 'sdcdm channel set' to " +
+                            'change the default channel):\n    %s',
                         imagesNotInTheChannel.join('\n    ')
                     )
                 );
@@ -4815,7 +4819,9 @@ maAdm.prototype.verifyPlan = function(opts, cb) {
                             'the "%s" channel and cannot be ' +
                             'provisioned. ' +
                             '(Use --skip-verify-channel to ' +
-                            'override):\n    %s',
+                            'override, -C to specify a different ' +
+                            "channel or 'sdcdm channel set' to " +
+                            'change the default channel):\n    %s',
                         self.ma_channel,
                         imagesNotInTheChannel.join('\n    ')
                     )

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "manta-deployment",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "manta-deployment",
     "description": "Manta deployment configuration",
-    "version": "1.3.1",
+    "version": "1.4.0",
     "author": "Joyent (joyent.com)",
     "license": "MPL-2.0",
     "private": true,


### PR DESCRIPTION
This is the updated PR for this change, my having broken the last one by accidentally merging a force-pushed change with upstream.

To be on the safe side, I re-tested these changes to ensure they were correct:

```
[root@2f5b146d-0274-4fd0-85b8-3bb40cf1ee03 (europe:manta0) ~]# manta-adm update new.json
logs at /var/log/manta-adm.log
manta-adm: The following images were not found on the "dev" channel and cannot be provisioned. (Use --skip-verify-channel to override, -C to specify a different channel or 'sdcdm channel set' to change the default channel):
    772e3824-20cc-41e0-9d87-e2db097279e9 (webapi)
The following images are not available in the local imgapi instance:
    772e3824-20cc-41e0-9d87-e2db097279e9 (webapi)
[root@2f5b146d-0274-4fd0-85b8-3bb40cf1ee03 (europe:manta0) ~]# manta-adm update -C experimental new.json
logs at /var/log/manta-adm.log
manta-adm: The following images are not available in the local imgapi instance:
    772e3824-20cc-41e0-9d87-e2db097279e9 (webapi)
[root@2f5b146d-0274-4fd0-85b8-3bb40cf1ee03 (europe:manta0) ~]#
[root@2f5b146d-0274-4fd0-85b8-3bb40cf1ee03 (europe:manta0) ~]#
[root@2f5b146d-0274-4fd0-85b8-3bb40cf1ee03 (europe:manta0) ~]# manta-adm update -C experimental new.json
logs at /var/log/manta-adm.log
service "webapi"
  cn "564d92c9-9467-036c-df5c-c8a9992fcbc7":
    reprovision zone 35af41ad-fe66-4887-a7ab-68b3e7bf827f
        (old image: 492ad127-4c64-4a57-b735-92f3c5336dd8)
        (new image: 772e3824-20cc-41e0-9d87-e2db097279e9)
Are you sure you want to proceed? (y/N): y

service "webapi": reprovisioning "35af41ad-fe66-4887-a7ab-68b3e7bf827f"
    server_uuid: 564d92c9-9467-036c-df5c-c8a9992fcbc7
      new image: 772e3824-20cc-41e0-9d87-e2db097279e9
service "webapi": reprovisioned "35af41ad-fe66-4887-a7ab-68b3e7bf827f"
[root@2f5b146d-0274-4fd0-85b8-3bb40cf1ee03 (europe:manta0) ~]# tail -300 /var/log/manta-adm.log | bunyan
.
.
.  (omitted output here)
.
.
[2020-01-10T15:47:49.496Z] DEBUG: manta-adm/66707 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: initializing SDC clients
[2020-01-10T15:47:49.813Z]  INFO: manta-adm/66707 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: UFDS: connected
[2020-01-10T15:47:49.813Z] DEBUG: manta-adm/66707 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: initialized SDC clients
[2020-01-10T15:47:49.813Z] DEBUG: manta-adm/ufds/66707 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: connected after 1 attempt(s) (clazz=Client, ldap_id=1__ldaps://ufds.europe.example.com)
[2020-01-10T15:47:49.816Z]  INFO: manta-adm/66707 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: fetching "manta" application
[2020-01-10T15:47:49.892Z]  INFO: manta-adm/66707 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: fetching "manta" application objects
[2020-01-10T15:47:49.981Z]  INFO: manta-adm/66707 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: listing VMs (state=active, owner_uuid=0e6d3db8-c409-480f-a79a-a7766678d9ff)
[2020-01-10T15:47:50.179Z]  INFO: manta-adm/66707 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: fetching info for CNs
[2020-01-10T15:47:50.579Z]  INFO: manta-adm/66707 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: fetching info for images
[2020-01-10T15:47:50.736Z]  INFO: manta-adm/66707 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: loaded current deployed state
[2020-01-10T15:47:50.799Z] DEBUG: manta-adm/66707 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: found sdc application
[2020-01-10T15:47:50.800Z]  INFO: manta-adm/66707 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: SDC update channel is dev
[2020-01-10T15:47:50.800Z]  INFO: manta-adm/66707 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: generating plan
[2020-01-10T15:47:50.800Z] DEBUG: manta-adm/66707 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: user config: processing CN (cnid=564d92c9-9467-036c-df5c-c8a9992fcbc7)
[2020-01-10T15:47:50.801Z] DEBUG: manta-adm/66707 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: match count in new config (cnid=564d92c9-9467-036c-df5c-c8a9992fcbc7, service=authcache, wanted=1, have=1, delta=0)
    config: [
      "64e9863f-0e13-405c-bc30-450da4188ae8"
    ]
[2020-01-10T15:47:50.801Z] DEBUG: manta-adm/66707 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: match count in new config (cnid=564d92c9-9467-036c-df5c-c8a9992fcbc7, service=electric-moray, wanted=1, have=1, delta=0)
    config: [
      "e8feeb38-4192-4a6f-a2ce-43aca7fbf44f"
    ]
[2020-01-10T15:47:50.801Z] DEBUG: manta-adm/66707 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: match count in new config (cnid=564d92c9-9467-036c-df5c-c8a9992fcbc7, service=loadbalancer, wanted=1, have=1, delta=0)
    config: [
      "133464f0-2f71-4d2f-93b9-39f1e4e01e9a"
    ]
[2020-01-10T15:47:50.801Z] DEBUG: manta-adm/66707 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: match count in new config (cnid=564d92c9-9467-036c-df5c-c8a9992fcbc7, service=moray, wanted=1, have=1, delta=0)
    config: [
      "1",
      "653bb6db-bf1d-4771-97a8-e2320dcb2632"
    ]
[2020-01-10T15:47:50.801Z] DEBUG: manta-adm/66707 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: match count in new config (cnid=564d92c9-9467-036c-df5c-c8a9992fcbc7, service=nameservice, wanted=1, have=1, delta=0)
    config: [
      "325745d7-eace-4c31-bc8d-1787200188ae"
    ]
[2020-01-10T15:47:50.801Z] DEBUG: manta-adm/66707 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: match count in new config (cnid=564d92c9-9467-036c-df5c-c8a9992fcbc7, service=ops, wanted=1, have=1, delta=0)
    config: [
      "374dff78-1241-4710-99dd-30b900bfd295"
    ]
[2020-01-10T15:47:50.801Z] DEBUG: manta-adm/66707 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: match count in new config (cnid=564d92c9-9467-036c-df5c-c8a9992fcbc7, service=postgres, wanted=2, have=2, delta=0)
    config: [
      "1",
      "add45ae2-459e-46ff-bd8e-695b70e3a02f"
    ]
[2020-01-10T15:47:50.801Z] DEBUG: manta-adm/66707 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: match count in new config (cnid=564d92c9-9467-036c-df5c-c8a9992fcbc7, service=storage, wanted=3, have=3, delta=0)
    config: [
      "2dc8f470-ca34-40af-90c2-b1f529644cad"
    ]
[2020-01-10T15:47:50.801Z] DEBUG: manta-adm/66707 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: match count in new config (cnid=564d92c9-9467-036c-df5c-c8a9992fcbc7, service=webapi, wanted=1, have=0, delta=1)
    config: [
      "772e3824-20cc-41e0-9d87-e2db097279e9"
    ]
[2020-01-10T15:47:50.801Z] DEBUG: manta-adm/66707 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: image not present in new config (cnid=564d92c9-9467-036c-df5c-c8a9992fcbc7, service=webapi, delta=-1)
    config: [
      "492ad127-4c64-4a57-b735-92f3c5336dd8"
    ]
[2020-01-10T15:47:50.805Z] DEBUG: manta-adm/66707 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: getting local image 772e3824-20cc-41e0-9d87-e2db097279e9 for service webapi
[2020-01-10T15:47:50.828Z] DEBUG: manta-adm/66707 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: missing local image 772e3824-20cc-41e0-9d87-e2db097279e9 (webapi)
[2020-01-10T15:47:50.829Z] DEBUG: manta-adm/66707 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: getting remote image 772e3824-20cc-41e0-9d87-e2db097279e9 for service webapi on channel dev
[2020-01-10T15:47:52.167Z] DEBUG: manta-adm/66707 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: missing remote image 772e3824-20cc-41e0-9d87-e2db097279e9 (webapi)
[2020-01-10T15:48:05.346Z] DEBUG: manta-adm/66772 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: initializing SDC clients
[2020-01-10T15:48:05.810Z]  INFO: manta-adm/66772 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: UFDS: connected
[2020-01-10T15:48:05.810Z] DEBUG: manta-adm/66772 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: initialized SDC clients
[2020-01-10T15:48:05.813Z] DEBUG: manta-adm/ufds/66772 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: connected after 1 attempt(s) (clazz=Client, ldap_id=1__ldaps://ufds.europe.example.com)
[2020-01-10T15:48:05.817Z]  INFO: manta-adm/66772 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: fetching "manta" application
[2020-01-10T15:48:05.907Z]  INFO: manta-adm/66772 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: fetching "manta" application objects
[2020-01-10T15:48:06.051Z]  INFO: manta-adm/66772 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: listing VMs (state=active, owner_uuid=0e6d3db8-c409-480f-a79a-a7766678d9ff)
[2020-01-10T15:48:06.237Z]  INFO: manta-adm/66772 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: fetching info for CNs
[2020-01-10T15:48:06.616Z]  INFO: manta-adm/66772 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: fetching info for images
[2020-01-10T15:48:06.692Z]  INFO: manta-adm/66772 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: loaded current deployed state
[2020-01-10T15:48:06.695Z]  INFO: manta-adm/66772 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: generating plan
[2020-01-10T15:48:06.695Z] DEBUG: manta-adm/66772 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: user config: processing CN (cnid=564d92c9-9467-036c-df5c-c8a9992fcbc7)
[2020-01-10T15:48:06.696Z] DEBUG: manta-adm/66772 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: match count in new config (cnid=564d92c9-9467-036c-df5c-c8a9992fcbc7, service=authcache, wanted=1, have=1, delta=0)
    config: [
      "64e9863f-0e13-405c-bc30-450da4188ae8"
    ]
[2020-01-10T15:48:06.696Z] DEBUG: manta-adm/66772 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: match count in new config (cnid=564d92c9-9467-036c-df5c-c8a9992fcbc7, service=electric-moray, wanted=1, have=1, delta=0)
    config: [
      "e8feeb38-4192-4a6f-a2ce-43aca7fbf44f"
    ]
[2020-01-10T15:48:06.696Z] DEBUG: manta-adm/66772 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: match count in new config (cnid=564d92c9-9467-036c-df5c-c8a9992fcbc7, service=loadbalancer, wanted=1, have=1, delta=0)
    config: [
      "133464f0-2f71-4d2f-93b9-39f1e4e01e9a"
    ]
[2020-01-10T15:48:06.696Z] DEBUG: manta-adm/66772 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: match count in new config (cnid=564d92c9-9467-036c-df5c-c8a9992fcbc7, service=moray, wanted=1, have=1, delta=0)
    config: [
      "1",
      "653bb6db-bf1d-4771-97a8-e2320dcb2632"
    ]
[2020-01-10T15:48:06.696Z] DEBUG: manta-adm/66772 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: match count in new config (cnid=564d92c9-9467-036c-df5c-c8a9992fcbc7, service=nameservice, wanted=1, have=1, delta=0)
    config: [
      "325745d7-eace-4c31-bc8d-1787200188ae"
    ]
[2020-01-10T15:48:06.696Z] DEBUG: manta-adm/66772 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: match count in new config (cnid=564d92c9-9467-036c-df5c-c8a9992fcbc7, service=ops, wanted=1, have=1, delta=0)
    config: [
      "374dff78-1241-4710-99dd-30b900bfd295"
    ]
[2020-01-10T15:48:06.696Z] DEBUG: manta-adm/66772 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: match count in new config (cnid=564d92c9-9467-036c-df5c-c8a9992fcbc7, service=postgres, wanted=2, have=2, delta=0)
    config: [
      "1",
      "add45ae2-459e-46ff-bd8e-695b70e3a02f"
    ]
[2020-01-10T15:48:06.696Z] DEBUG: manta-adm/66772 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: match count in new config (cnid=564d92c9-9467-036c-df5c-c8a9992fcbc7, service=storage, wanted=3, have=3, delta=0)
    config: [
      "2dc8f470-ca34-40af-90c2-b1f529644cad"
    ]
[2020-01-10T15:48:06.697Z] DEBUG: manta-adm/66772 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: match count in new config (cnid=564d92c9-9467-036c-df5c-c8a9992fcbc7, service=webapi, wanted=1, have=0, delta=1)
    config: [
      "772e3824-20cc-41e0-9d87-e2db097279e9"
    ]
[2020-01-10T15:48:06.697Z] DEBUG: manta-adm/66772 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: image not present in new config (cnid=564d92c9-9467-036c-df5c-c8a9992fcbc7, service=webapi, delta=-1)
    config: [
      "492ad127-4c64-4a57-b735-92f3c5336dd8"
    ]
[2020-01-10T15:48:06.702Z] DEBUG: manta-adm/66772 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: getting local image 772e3824-20cc-41e0-9d87-e2db097279e9 for service webapi
[2020-01-10T15:48:06.709Z] DEBUG: manta-adm/66772 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: missing local image 772e3824-20cc-41e0-9d87-e2db097279e9 (webapi)
[2020-01-10T15:48:06.709Z] DEBUG: manta-adm/66772 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: getting remote image 772e3824-20cc-41e0-9d87-e2db097279e9 for service webapi on channel experimental
[2020-01-10T15:51:15.433Z] DEBUG: manta-adm/67547 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: initializing SDC clients
[2020-01-10T15:51:15.773Z]  INFO: manta-adm/67547 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: UFDS: connected
[2020-01-10T15:51:15.773Z] DEBUG: manta-adm/67547 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: initialized SDC clients
[2020-01-10T15:51:15.774Z] DEBUG: manta-adm/ufds/67547 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: connected after 1 attempt(s) (clazz=Client, ldap_id=1__ldaps://ufds.europe.example.com)
[2020-01-10T15:51:15.778Z]  INFO: manta-adm/67547 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: fetching "manta" application
[2020-01-10T15:51:15.857Z]  INFO: manta-adm/67547 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: fetching "manta" application objects
[2020-01-10T15:51:15.983Z]  INFO: manta-adm/67547 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: listing VMs (state=active, owner_uuid=0e6d3db8-c409-480f-a79a-a7766678d9ff)
[2020-01-10T15:51:16.177Z]  INFO: manta-adm/67547 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: fetching info for CNs
[2020-01-10T15:51:16.623Z]  INFO: manta-adm/67547 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: fetching info for images
[2020-01-10T15:51:16.916Z]  INFO: manta-adm/67547 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: loaded current deployed state
[2020-01-10T15:51:16.921Z]  INFO: manta-adm/67547 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: generating plan
[2020-01-10T15:51:16.922Z] DEBUG: manta-adm/67547 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: user config: processing CN (cnid=564d92c9-9467-036c-df5c-c8a9992fcbc7)
[2020-01-10T15:51:16.923Z] DEBUG: manta-adm/67547 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: match count in new config (cnid=564d92c9-9467-036c-df5c-c8a9992fcbc7, service=authcache, wanted=1, have=1, delta=0)
    config: [
      "64e9863f-0e13-405c-bc30-450da4188ae8"
    ]
[2020-01-10T15:51:16.923Z] DEBUG: manta-adm/67547 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: match count in new config (cnid=564d92c9-9467-036c-df5c-c8a9992fcbc7, service=electric-moray, wanted=1, have=1, delta=0)
    config: [
      "e8feeb38-4192-4a6f-a2ce-43aca7fbf44f"
    ]
[2020-01-10T15:51:16.923Z] DEBUG: manta-adm/67547 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: match count in new config (cnid=564d92c9-9467-036c-df5c-c8a9992fcbc7, service=loadbalancer, wanted=1, have=1, delta=0)
    config: [
      "133464f0-2f71-4d2f-93b9-39f1e4e01e9a"
    ]
[2020-01-10T15:51:16.923Z] DEBUG: manta-adm/67547 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: match count in new config (cnid=564d92c9-9467-036c-df5c-c8a9992fcbc7, service=moray, wanted=1, have=1, delta=0)
    config: [
      "1",
      "653bb6db-bf1d-4771-97a8-e2320dcb2632"
    ]
[2020-01-10T15:51:16.924Z] DEBUG: manta-adm/67547 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: match count in new config (cnid=564d92c9-9467-036c-df5c-c8a9992fcbc7, service=nameservice, wanted=1, have=1, delta=0)
    config: [
      "325745d7-eace-4c31-bc8d-1787200188ae"
    ]
[2020-01-10T15:51:16.924Z] DEBUG: manta-adm/67547 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: match count in new config (cnid=564d92c9-9467-036c-df5c-c8a9992fcbc7, service=ops, wanted=1, have=1, delta=0)
    config: [
      "374dff78-1241-4710-99dd-30b900bfd295"
    ]
[2020-01-10T15:51:16.924Z] DEBUG: manta-adm/67547 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: match count in new config (cnid=564d92c9-9467-036c-df5c-c8a9992fcbc7, service=postgres, wanted=2, have=2, delta=0)
    config: [
      "1",
      "add45ae2-459e-46ff-bd8e-695b70e3a02f"
    ]
[2020-01-10T15:51:16.924Z] DEBUG: manta-adm/67547 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: match count in new config (cnid=564d92c9-9467-036c-df5c-c8a9992fcbc7, service=storage, wanted=3, have=3, delta=0)
    config: [
      "2dc8f470-ca34-40af-90c2-b1f529644cad"
    ]
[2020-01-10T15:51:16.924Z] DEBUG: manta-adm/67547 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: match count in new config (cnid=564d92c9-9467-036c-df5c-c8a9992fcbc7, service=webapi, wanted=1, have=0, delta=1)
    config: [
      "772e3824-20cc-41e0-9d87-e2db097279e9"
    ]
[2020-01-10T15:51:16.925Z] DEBUG: manta-adm/67547 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: image not present in new config (cnid=564d92c9-9467-036c-df5c-c8a9992fcbc7, service=webapi, delta=-1)
    config: [
      "492ad127-4c64-4a57-b735-92f3c5336dd8"
    ]
[2020-01-10T15:51:16.929Z] DEBUG: manta-adm/67547 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: getting local image 772e3824-20cc-41e0-9d87-e2db097279e9 for service webapi
[2020-01-10T15:51:16.951Z] DEBUG: manta-adm/67547 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: getting remote image 772e3824-20cc-41e0-9d87-e2db097279e9 for service webapi on channel experimental
[2020-01-10T15:51:19.331Z]  INFO: manta-adm/67547 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: initing sdc clients
[2020-01-10T15:51:19.450Z]  INFO: manta-adm/67547 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: UFDS: connected
[2020-01-10T15:51:19.451Z] DEBUG: manta-adm/ufds/67547 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: connected after 1 attempt(s) (clazz=Client, ldap_id=2__ldaps://ufds.europe.example.com)
[2020-01-10T15:51:19.451Z]  INFO: manta-adm/67547 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: getting poseidon user
[2020-01-10T15:51:19.617Z]  INFO: manta-adm/67547 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: finding "sdc" application
[2020-01-10T15:51:19.683Z]  INFO: manta-adm/67547 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: finding "manta" application
[2020-01-10T15:51:19.743Z] DEBUG: manta-adm/67547 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: found manta application
    app: {
      "uuid": "c885ac64-33c6-4b6d-8f94-01c3da9a5701",
      "name": "manta",
      "owner_uuid": "0e6d3db8-c409-480f-a79a-a7766678d9ff",
      "params": {
        "delegate_dataset": true
      },
      "metadata": {
        "MANTAV": 2,
        "REGION": "earth",
        "SIZE": "coal",
        "DNS_DOMAIN": "example.com",
        "DOMAIN_NAME": "earth.example.com",
        "MANTA_SERVICE": "manta.earth.example.com",
        "AUTH_SERVICE": "authcache.earth.example.com",
        "ELECTRIC_MORAY": "electric-moray.earth.example.com",
        "BUCKETS_MDPLACEMENT": "buckets-mdplacement.earth.example.com",
        "POSEIDON_UUID": "0e6d3db8-c409-480f-a79a-a7766678d9ff",
        "IMGAPI_SERVICE": "http://imgapi.europe.example.com/",
        "WORKFLOW_SERVICE": "workflow.earth.example.com",
        "MANTA_URL": "https://manta.earth.example.com",
        "MANTA_REJECT_UNAUTHORIZED": false,
        "MANTA_TLS_INSECURE": "1",
        "MUSKIE_MULTI_DC": false,
        "BUCKETS_API_MULTI_DC": false,
        "MAKO_HTTP_KEEPALIVE_TIMEOUT": 86400,
        "SERVER_COMPUTE_ID_MAPPING": {
          "564d92c9-9467-036c-df5c-c8a9992fcbc7": "1.cn.earth.example.com"
        },
        "ADMIN_USERNAME": "poseidon",
        "ADMIN_PRIVATE_KEY": "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEAlL8S5FAbR63ZLlG9YVc03pCHXrusaYjewGUbsOiAR2GrihLy\nGgbiHyt1isK80mpwbqC8lCuMCTxkMvEk1f7ZdPR6JekS8hwUimaKQy0WL4UzJDrQ\naWCkWDRNiHWzdR+7Vec2ZBfoyb5WhPCr7Tcv54uym6hQdwR2Y9U/JPkjr/V8vsaK\nLjGWU+bHnRrwuPaZmXkROYtS3vxD6IibVD4sJPDMSYkV/apWOgZtdwBswiY7udYV\nu7yKGPOnDVfSuIUscGEJKAj/FzwCni8h3rJc6SkwTJO9OWUsIp+10cQ4b2mEIIe5\nZkWCQ1SJnXS5KPm4PDGJR4stdsve8NTPovWGTQIDAQABAoIBAAd/Jc2Z9/YB3gtG\nlVvdkE2TTS9KGCNtgYSC1AVzgluWoZWg5NDI/gaCIzduHyQftzDsKvTwyOsCPy6O\nFsQuRvltBOb6Ozk2jxZ2motOL2sPtIcj67MT6tSDNlElVXkWs1NeBtC+n73jOOsU\nUiXvfRuXX9YWgo+tCuZ3LeqIH/NTQV1GUv3y6xpJKG1lRJcNf0IzY/gyuCn0B4Jx\ngKx7+h1Pm9x5tB4rY9UkNleRCurCfjfyrlYLlUra64UqaWJexeI+OuwQvmubmRyr\nmbCZuXMQM7Q7cHd/QM7nudzLDW1B/ZzX69WlsJVKIMA3EvgurKsfput3iHjyVTqF\nCJ67+uUCgYEAxd2oYbfoDysHz51taBVM48BDI6THvmTCZ1kKDpvux17lvfcB27ut\ndTllrjqCAwEyIDs+aRO4VEahhPsBcjQr7O1SZYxD/4FhROFlaZ97fZySRo9K48/r\ncPO+H7XYZWaQ3k5F08awqN1VVwQlt+YE5NGACltIkaM5nicXHe00a1sCgYEAwHLt\n7djNq6YZbhLsPJTuH5bQ2RL3ewDqTiWLLIlyTVg9V/IlNwMrTe8H3nzyyeAoCaJU\niGexfGUZcpfOi4yhJ0Bkz+spLNI6yrzPbVx6r36vWGIgkeEqV5OYv9gcU1v6I9uY\nG5m6WAsu3Ds7El7O7/RRYsd80eNR6PxovM+sDXcCgYEAktPBN4I4+ch8q1uu7CWi\nQP9S0whcELTEbdxs0hp0Pg31fdnlzyCdvvcwtPFFuOUSRUixL1gq2J7xDLUWhaCh\nV9dj5WcIrnlbrLl1f8OQ581f3mxGrnaDx/WXiABw7A4IQm7i8hvmy+gyg7fYJXbS\n+tlbolPKrgfpoapwRQzYcTECgYEApz652uuAwV0V2H0FZBihYD52vU8oV3MSLFug\nOVIxTVoT5WwAP3C3n4DNO+MmM55j7QtvnyNOMSbDGL0ouEm8exoRAkgBfnwsr6eq\nNAYccIsN4ydT2rLtUzJnmsE6zI6wMZ1S8RmFwaHmVWn8ChjuicWvPMLUjKqasnk4\npG1tvj0CgYBVYcPAh5sVeI/ixXzY1shKTFj0fFkeGiGZnBP+qDn77k6AHO6Y6VWv\nyQe9t3bM4YWPk09n5XtMGWHxM+qYTU61UjFzJZxPGVIorQixet9jQSMpWC9MoqvI\nZ7Bb6HLs44bAZWoNt5aAY+5WfTLQq98Hea+5A4CSKOjeCaret3twpA==\n-----END RSA PRIVATE KEY-----",
        "ADMIN_PUBLIC_KEY": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCUvxLkUBtHrdkuUb1hVzTekIdeu6xpiN7AZRuw6IBHYauKEvIaBuIfK3WKwrzSanBuoLyUK4wJPGQy8STV/tl09Hol6RLyHBSKZopDLRYvhTMkOtBpYKRYNE2IdbN1H7tV5zZkF+jJvlaE8KvtNy/ni7KbqFB3BHZj1T8k+SOv9Xy+xoouMZZT5sedGvC49pmZeRE5i1Le/EPoiJtUPiwk8MxJiRX9qlY6Bm13AGzCJju51hW7vIoY86cNV9K4hSxwYQkoCP8XPAKeLyHeslzpKTBMk705ZSwin7XRxDhvaYQgh7lmRYJDVImddLko+bg8MYlHiy12y97w1M+i9YZN root@2f5b146d-0274-4fd0-85b8-3bb40cf1ee03",
        "ADMIN_KEY_ID": "93:bd:eb:9b:f1:96:60:1c:1b:ac:35:9b:ff:a2:e9:3e",
        "INDEX_MORAY_SHARDS": [
          {
            "host": "1.moray.earth.example.com",
            "last": true
          }
        ],
        "STORAGE_MORAY_SHARD": "1.moray.earth.example.com",
        "HASH_RING_IMAGE": "89006d0d-4126-45b4-bc84-fdf512c46780",
        "HASH_RING_IMGAPI_SERVICE": "http://imgapi.europe.example.com",
        "ZK_SERVERS": [
          {
            "host": "10.77.77.42",
            "port": 2181,
            "num": 1,
            "last": true
          }
        ]
      },
      "master": true,
      "manifests": {
        "registrar": "69db7842-99dd-4baa-8cc6-568624b38683",
        "common": "5211da1a-0607-40f0-bcef-c92a11b71d91",
        "dns_client": "1a72434b-0e8e-4aee-8f53-44023c8807df",
        "ssh_private_key": "1946bf32-22a3-4d4f-a292-133cd033526a",
        "ssh_public_key": "938de3d4-dbc8-419d-b4fd-7e357fa189bf"
      }
    }
[2020-01-10T15:51:19.746Z]  INFO: manta-adm/67547 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: fetching "manta" application services (include_master=true, application_uuid=c885ac64-33c6-4b6d-8f94-01c3da9a5701)
[2020-01-10T15:51:19.816Z]  INFO: manta-adm/67547 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: checking shard configuration parameters
[2020-01-10T15:51:19.816Z]  INFO: manta-adm/67547 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: checking shard configuration parameters
[2020-01-10T15:51:19.823Z] DEBUG: manta-adm/67547 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: reprovisioned (cnid=564d92c9-9467-036c-df5c-c8a9992fcbc7, service=webapi, zone=35af41ad-fe66-4887-a7ab-68b3e7bf827f, image=772e3824-20cc-41e0-9d87-e2db097279e9)
[2020-01-10T15:52:06.421Z] DEBUG: manta-adm/67547 on 2f5b146d-0274-4fd0-85b8-3bb40cf1ee03: reprovisioned (cnid=564d92c9-9467-036c-df5c-c8a9992fcbc7, service=webapi, zone=35af41ad-fe66-4887-a7ab-68b3e7bf827f)
[root@2f5b146d-0274-4fd0-85b8-3bb40cf1ee03 (europe:manta0) ~]#
```