### PR TITLE
MANTA-4965 manta-deploy-lab should support multiple servers

### DIFF
--- a/bin/manta-deploy-dev
+++ b/bin/manta-deploy-dev
@@ -27,6 +27,25 @@ RING_EXISTS_EXIT_STATUS=3
 
 # ---- internal functions
 
+function usage () {
+	echo "Usage:"
+	echo "    $(basename $0) [OPTIONS] coal|lab"
+	echo ""
+	echo "Options:"
+	echo "    -h          Show this help and exit."
+	echo "    -y          Skip confirmations."
+	echo ""
+	echo "  'lab' options:"
+	echo "    -s SERVERS    Comma-separated list of server UUIDs to use for"
+	echo "                  for deployment. Defaults to all servers."
+	echo "    -S SERVERS    Comma-separated list of server UUIDs to use for"
+	echo "                  for deployment of *storage* instances. Defaults"
+	echo "                  the value for '-s SERVERS'."
+	echo "    -1 SVCNAMES   Comma-separated list of service names for which"
+	echo "                  to ensure at least one instance is deployed to"
+	echo "                  the headnode, for developer convenience."
+}
+
 #
 # fail ERRMESSAGE: prints the error message to stderr and exits
 #
@@ -61,42 +80,69 @@ function confirm
 mdl_tmpdir="${TMPDIR:-/var/tmp}"
 mdl_conffile="$mdl_tmpdir/lab-config.json"
 mdl_override="false"		# override confirmation prompts
-mdl_topo_size=			# number of fash virtual nodes
-mdl_dir_index_shards=		# manatee shards to use for indexing tier
-mdl_genconfig=			# manta-adm genconfig kind
+mdl_size=			# manta-adm genconfig 'SIZE' arg
+mdl_servers=			# manta-adm genconfig '-s SERVERS' opt
+mdl_storage_servers=		# manta-adm genconfig '-S SERVERS' opt
+mdl_one_on_headnode=		# manta-adm genconfig '-1 SVCNAMES' opt
 
-if [[ "$1" == "-y" ]]; then
-	shift
-	mdl_override="true"
-	echo "note: bypassing confirmations" >&2
-fi
+while getopts "hys:S:1:" opt; do
+	case "$opt" in
+	h)
+		usage
+		exit 0
+		;;
+	y)
+		mdl_override="true"
+		;;
+	s)
+		mdl_servers=$OPTARG
+		;;
+	S)
+		mdl_storage_servers=$OPTARG
+		;;
+	1)
+		mdl_one_on_headnode=$OPTARG
+		;;
+	*)
+		echo "error: invalid option '-$opt'" >&2
+		usage
+		exit 2
+		;;
+	esac
+done
+shift $(( OPTIND - 1 ))
 
 case "$1" in
 	coal)
-		mdl_genconfig="coal"
+		mdl_size="coal"
 		mdl_dir_index_shards="1.moray"
 		mdl_dir_topo_size=100000
 		mdl_buckets_index_shards="1.buckets-mdapi"
 		mdl_buckets_topo_size=4
 		;;
 	lab)
-		mdl_genconfig="lab"
+		mdl_size="lab"
 		mdl_dir_index_shards="1.moray 2.moray"
 		mdl_dir_topo_size=131072
 		mdl_buckets_index_shards="1.buckets-mdapi 2.buckets-mdapi"
 		mdl_buckets_topo_size=16
 		;;
 	*)
-		echo "usage: $(basename $0) [-y] coal | lab" >&2
+		echo "error: invalid genconfig size: must be one of 'coal' or 'lab'" >&2
+		usage
 		exit 2
 		;;
 esac
 
-echo "genconfig mode:        $mdl_genconfig" >&2
-echo "dir index shards:      $mdl_dir_index_shards" >&2
-echo "dir vnodes:            $mdl_dir_topo_size" >&2
-echo "buckets index shards:  $mdl_buckets_index_shards" >&2
-echo "buckets vnodes:        $mdl_buckets_topo_size" >&2
+echo "genconfig size:          $mdl_size" >&2
+echo "dir index shards:        $mdl_dir_index_shards" >&2
+echo "dir vnodes:              $mdl_dir_topo_size" >&2
+echo "buckets index shards:    $mdl_buckets_index_shards" >&2
+echo "buckets vnodes:          $mdl_buckets_topo_size" >&2
+echo "deploy servers:          $mdl_servers" >&2
+echo "deploy storage servers:  $mdl_storage_servers" >&2
+echo "deploy on on headnode:   $mdl_one_on_headnode" >&2
+
 
 # Directory API shard/topology setup
 
@@ -143,7 +189,17 @@ set -o errexit
 # ensure nameservice is setup first. Perhaps it should also wait to ensure
 # nameservice is up and working before proceeding.
 
-manta-adm genconfig $mdl_genconfig > $mdl_conffile
+genconfig_opts=
+if [[ -n "$mdl_servers" ]]; then
+    genconfig_opts+=" -s $mdl_servers"
+fi
+if [[ -n "$mdl_storage_servers" ]]; then
+    genconfig_opts+=" -S $mdl_storage_servers"
+fi
+if [[ -n "$mdl_one_on_headnode" ]]; then
+    genconfig_opts+=" -1 $mdl_one_on_headnode"
+fi
+manta-adm genconfig $genconfig_opts $mdl_size > $mdl_conffile
 manta-adm update --skip-verify-channel -y $mdl_conffile nameservice
 
 set +o xtrace

--- a/bin/manta-deploy-dev
+++ b/bin/manta-deploy-dev
@@ -141,7 +141,7 @@ echo "buckets index shards:    $mdl_buckets_index_shards" >&2
 echo "buckets vnodes:          $mdl_buckets_topo_size" >&2
 echo "deploy servers:          $mdl_servers" >&2
 echo "deploy storage servers:  $mdl_storage_servers" >&2
-echo "deploy on on headnode:   $mdl_one_on_headnode" >&2
+echo "deploy one on headnode:  $mdl_one_on_headnode" >&2
 
 
 # Directory API shard/topology setup

--- a/lib/adm.js
+++ b/lib/adm.js
@@ -2320,13 +2320,16 @@ maAdm.prototype.amonUpdatePlanApply = function amonUpdatePlanApply(
 };
 
 /*
- * The dumpConfig.* functions dump sample configurations based on common
- * deployments in development and test.
+ * Generate a minimal Manta deployment suitable (as much as possible) for
+ * usage in COAL: a single headnode in a VM, likely limited in available RAM.
  */
-
 maAdm.prototype.dumpConfigCoal = function(options, callback) {
     return this.dumpConfigCommon(
-        options,
+        {
+            outstream: options.outstream,
+            // Explicitly limit COAL Manta deployment to the headnode.
+            servers: ['headnode']
+        },
         {
             shards: ['1'],
             nameservice: 1,
@@ -2351,7 +2354,8 @@ maAdm.prototype.dumpConfigCoal = function(options, callback) {
 
 /*
  * Generate a reasonable "lab"-sized Manta deployment configuration. "lab"-sized
- * here means something bigger (i.e. more RAM) than COAL, but still constrained.
+ * here means something bigger (i.e. more RAM) than COAL, but still constrained
+ * typically to one or a few servers.
  *
  * Goals of the numbers here:
  * - 3 for nameservice and postgres clusters to test HA
@@ -2369,6 +2373,11 @@ maAdm.prototype.dumpConfigLab = function(options, callback) {
             postgres: 3,
             moray: 2,
             'electric-moray': 1,
+            // Number of storage nodes for dev: Having just 2 would be nice
+            // because default ncopies=2 would mean a file is always written
+            // to all the storage nodes if you go looking. Having 3 is nice
+            // for rebalancer evacuation testing, b/c it has more than one
+            // target node for data.
             storage: 3,
             authcache: 1,
             webapi: 1,
@@ -2385,36 +2394,306 @@ maAdm.prototype.dumpConfigLab = function(options, callback) {
     );
 };
 
-maAdm.prototype.dumpConfigCommon = function(options, conf, callback) {
+maAdm.prototype.dumpConfigCommon = function(options, numFromSvcName, callback) {
+    assertplus.object(options, 'options');
+    assertplus.object(options.outstream, 'options.outstream');
+    // An array of servers (hostname or UUID) on which to deploy service insts.
+    assertplus.optionalArrayOfString(options.servers, 'options.servers');
+    // An array of servers (hostname or UUID) on which to deploy "storage"
+    // service insts.
+    assertplus.optionalArrayOfString(
+        options.storageServers,
+        'options.storageServers'
+    );
+    // An array of service names for which to ensure at least one instance is
+    // deployed to the headnode. This is for developer convenience.
+    assertplus.optionalArrayOfString(
+        options.oneOnHnSvcNames,
+        'options.oneOnHnSvcNames'
+    );
+    assertplus.object(numFromSvcName, 'numFromSvcName');
+    assertplus.func(callback, 'callback');
+
     var self = this;
-    var sout = options.outstream;
+    var warn = function() {
+        console.error.apply(null, arguments);
+    };
 
-    /*
-     * COAL and lab configurations are hardcoded to use the headnode for
-     * provisioning.  Use CNAPI to find the appropriate uuid.
-     */
-    self.ma_sdc.CNAPI.listServers({headnode: true}, function(err, servers) {
-        var nwarnings, server_uuid;
+    vasync.pipeline(
+        {
+            arg: {},
+            funcs: [
+                function loadServers(ctx, next) {
+                    self.ma_sdc.CNAPI.listServers({}, function(
+                        err,
+                        allServers
+                    ) {
+                        if (err) {
+                            next(err);
+                            return;
+                        }
 
-        if (
-            !err &&
-            (!servers ||
-                !Array.isArray(servers) ||
-                servers.length !== 1 ||
-                servers[0].headnode !== true)
-        ) {
-            err = new VError('expected array of exactly 1 headnode server');
+                        for (let s of allServers) {
+                            if (s.headnode) {
+                                if (ctx.headnodeUuid) {
+                                    next(
+                                        new VError(
+                                            'found more than one "headnode=true" server from CNAPI, %s and %s: expected exactly 1',
+                                            ctx.headnodeUuid,
+                                            s.uuid
+                                        )
+                                    );
+                                    return;
+                                }
+                                ctx.headnodeUuid = s.uuid;
+                            }
+                        }
+                        if (!ctx.headnodeUuid) {
+                            next(
+                                new VError(
+                                    'could not find the headnode server from CNAPI'
+                                )
+                            );
+                            return;
+                        }
+
+                        ctx.setupServers = allServers.filter(function(s) {
+                            return s.setup;
+                        });
+                        if (ctx.setupServers.length === 0) {
+                            next(
+                                new VError(
+                                    'did not find any *setup* servers from CNAPI'
+                                )
+                            );
+                            return;
+                        }
+
+                        ctx.setupServerFromName = {};
+                        for (let s of ctx.setupServers) {
+                            ctx.setupServerFromName[s.uuid] = s;
+                            ctx.setupServerFromName[s.hostname] = s;
+                        }
+
+                        next();
+                    });
+                },
+
+                // Check the server options and normalize them to arrays of server
+                // UUIDs.
+                function ensureServerOpts(ctx, next) {
+                    if (!options.servers || options.servers.length === 0) {
+                        ctx.serverUuids = ctx.setupServers.map(function(s) {
+                            return s.uuid;
+                        });
+                    } else {
+                        ctx.serverUuids = [];
+                        for (let uuidOrHostname of options.servers) {
+                            let s = ctx.setupServerFromName[uuidOrHostname];
+                            if (!s) {
+                                next(
+                                    new VError(
+                                        '"%s" is not the UUID or hostname of a setup server',
+                                        uuidOrHostname
+                                    )
+                                );
+                                return;
+                            }
+                            ctx.serverUuids.push(s.uuid);
+                        }
+                    }
+
+                    if (
+                        !options.storageServers ||
+                        options.storageServers.length === 0
+                    ) {
+                        ctx.storageServerUuids = ctx.serverUuids.slice();
+                    } else {
+                        ctx.storageServerUuids = [];
+                        for (let uuidOrHostname of options.storageServers) {
+                            let s = ctx.setupServerFromName[uuidOrHostname];
+                            if (!s) {
+                                next(
+                                    new VError(
+                                        '"%s" is not the UUID or hostname of a setup server',
+                                        uuidOrHostname
+                                    )
+                                );
+                                return;
+                            }
+                            ctx.storageServerUuids.push(s.uuid);
+                        }
+                    }
+
+                    next();
+                },
+
+                // Which server for instances? Some guidelines:
+                // - Spread "storage" insts across all "storageServers" and warn if
+                //   there aren't enough servers.
+                // - Spread other insts of a given service across all "servers" and
+                //   warn if there aren't enough servers.
+                // - Bias (for now) to having one of everything on the headnode to
+                //   facilitate dev/debugging, if the headnode is one of the
+                //   servers.
+                function createLayout(ctx, next) {
+                    let imageFromSvcName = self.latestImagesByService();
+                    let shards = numFromSvcName['shards'];
+                    let sIdx = 0;
+
+                    ctx.config = {};
+
+                    let addInst = function(svr, svcName, img, shard) {
+                        assertplus.uuid(svr, 'svr');
+                        assertplus.string(svcName, 'svcName');
+                        assertplus.uuid(img, 'img');
+                        assertplus.optionalString(shard, 'shard');
+
+                        if (!ctx.config[svr]) {
+                            ctx.config[svr] = {};
+                        }
+                        if (!ctx.config[svr][svcName]) {
+                            ctx.config[svr][svcName] = {};
+                        }
+                        if (shard) {
+                            if (!ctx.config[svr][svcName][shard]) {
+                                ctx.config[svr][svcName][shard] = {};
+                            }
+                            if (!ctx.config[svr][svcName][shard][img]) {
+                                ctx.config[svr][svcName][shard][img] = 1;
+                            } else {
+                                ctx.config[svr][svcName][shard][img] += 1;
+                            }
+                        } else {
+                            if (!ctx.config[svr][svcName][img]) {
+                                ctx.config[svr][svcName][img] = 1;
+                            } else {
+                                ctx.config[svr][svcName][img] += 1;
+                            }
+                        }
+                    };
+
+                    for (let svcName of svcs.mSvcNames) {
+                        let num = numFromSvcName[svcName];
+                        if (!num) {
+                            continue;
+                        }
+
+                        let imageUuid = imageFromSvcName[svcName];
+                        if (!imageUuid) {
+                            warn(
+                                'warning: no image found for service "%s" (skipped)',
+                                svcName
+                            );
+                            continue;
+                        }
+
+                        let serverUuids =
+                            svcName === 'storage'
+                                ? ctx.storageServerUuids
+                                : ctx.serverUuids;
+                        if (num > serverUuids.length) {
+                            warn(
+                                'warning: there are fewer servers (%d) than instances of service "%s" (%d)',
+                                serverUuids.length,
+                                svcName,
+                                num
+                            );
+                        }
+
+                        let hnIdx = serverUuids.indexOf(ctx.headnodeUuid);
+
+                        // Handle 'storage' service layout independently of `sIdx`.
+                        if (svcName === 'storage') {
+                            let ssIdx = 0;
+                            if (
+                                options.oneOnHnSvcNames.indexOf(svcName) !==
+                                    -1 &&
+                                hnIdx !== -1
+                            ) {
+                                ssIdx = hnIdx;
+                            }
+                            for (let n = 0; n < num; n++) {
+                                addInst(serverUuids[ssIdx], svcName, imageUuid);
+                                // Advance to next server.
+                                ssIdx = (ssIdx + 1) % serverUuids.length;
+                            }
+                            continue;
+                        }
+
+                        if (
+                            options.oneOnHnSvcNames.indexOf(svcName) !== -1 &&
+                            hnIdx !== -1
+                        ) {
+                            // This service wants to ensure at least one instance
+                            // is on the headnode. To handle that we reset the
+                            // server index to the index of the headnode.
+                            //
+                            // A limitation due to this is that we aren't equally
+                            // balancing instances across all servers, but then
+                            // we aren't really doing so anyway because services
+                            // differ in capacity requirements.
+                            sIdx = hnIdx;
+                        }
+
+                        if (svcs.serviceIsSharded(svcName)) {
+                            for (let shard of shards) {
+                                for (let n = 0; n < num; n++) {
+                                    addInst(
+                                        serverUuids[sIdx],
+                                        svcName,
+                                        imageUuid,
+                                        shard
+                                    );
+                                    // Advance to next server.
+                                    sIdx = (sIdx + 1) % serverUuids.length;
+                                }
+                            }
+                        } else {
+                            for (let n = 0; n < num; n++) {
+                                addInst(serverUuids[sIdx], svcName, imageUuid);
+                                // Advance to next server.
+                                sIdx = (sIdx + 1) % serverUuids.length;
+                            }
+                        }
+                    }
+
+                    next();
+                },
+
+                // Sort config by CN UUID and service name (helps comparison).
+                function sortConfig(ctx, next) {
+                    var sortedConfig = {};
+                    Object.keys(ctx.config)
+                        .sort()
+                        .forEach(function(serverUuid) {
+                            var serverConfig = {};
+                            Object.keys(ctx.config[serverUuid])
+                                .sort()
+                                .forEach(function(svcName) {
+                                    serverConfig[svcName] =
+                                        ctx.config[serverUuid][svcName];
+                                });
+                            sortedConfig[serverUuid] = serverConfig;
+                        });
+                    ctx.config = sortedConfig;
+                    next();
+                },
+
+                function emitConfig(ctx, next) {
+                    options.outstream.write(
+                        JSON.stringify(ctx.config, null, 4) + '\n'
+                    );
+                    next();
+                }
+            ]
+        },
+        function finish(err) {
+            // Explicitly set number of errors to *0* here because we won't want
+            // `manta-adm genconfig lab` to exit non-zero on these.
+            callback(err, 0);
         }
-
-        if (err) {
-            callback(err);
-            return;
-        }
-
-        server_uuid = servers[0].uuid;
-        nwarnings = self.dumpConfigCommonFini(conf, sout, server_uuid);
-        callback(null, nwarnings);
-    });
+    );
 };
 
 maAdm.prototype.latestImagesByService = function() {
@@ -3699,18 +3978,18 @@ maAdm.prototype.isServiceDeployed = function(svcname) {
 };
 
 maAdm.prototype.getDeployedConfigByServiceJson = function() {
-    var self;
-    var rv;
+    var self = this;
+    var configFromCn;
+    var config;
     var svcuuids;
 
-    self = this;
     svcuuids = Object.keys(this.ma_config_bycn).sort(function(s1, s2) {
         return self.ma_services[s1]['name'].localeCompare(
             self.ma_services[s2]['name']
         );
     });
 
-    rv = {};
+    configFromCn = {};
     svcuuids.forEach(function(svcid) {
         var svcname, cnid, sc;
 
@@ -3718,16 +3997,26 @@ maAdm.prototype.getDeployedConfigByServiceJson = function() {
         for (cnid in self.ma_config_bycn[svcid]) {
             sc = self.ma_config_bycn[svcid][cnid];
 
-            if (!rv.hasOwnProperty(cnid)) {
-                rv[cnid] = {};
+            if (!configFromCn.hasOwnProperty(cnid)) {
+                configFromCn[cnid] = {};
             }
 
-            assert.ok(!rv[cnid].hasOwnProperty(svcname));
-            rv[cnid][svcname] = sc.summary();
+            assert.ok(!configFromCn[cnid].hasOwnProperty(svcname));
+            configFromCn[cnid][svcname] = sc.summary();
         }
     });
 
-    return rv;
+    // For comparison it useful to have a stable ordering. Sort the config by
+    // CN UUID. (Within each CN object, entries are already sorted by service
+    // name.)
+    config = {};
+    Object.keys(configFromCn)
+        .sort()
+        .forEach(function(cnid) {
+            config[cnid] = configFromCn[cnid];
+        });
+
+    return config;
 };
 
 maAdm.prototype.dumpDeployedConfigByServiceJson = function(sout, _conf) {

--- a/lib/adm.js
+++ b/lib/adm.js
@@ -2528,14 +2528,22 @@ maAdm.prototype.dumpConfigCommon = function(options, numFromSvcName, callback) {
                     next();
                 },
 
-                // Which server for instances? Some guidelines:
-                // - Spread "storage" insts across all "storageServers" and warn if
-                //   there aren't enough servers.
-                // - Spread other insts of a given service across all "servers" and
-                //   warn if there aren't enough servers.
-                // - Bias (for now) to having one of everything on the headnode to
-                //   facilitate dev/debugging, if the headnode is one of the
-                //   servers.
+                // This step decides on which server to place each Manta inst.
+                //
+                // Some guidelines being used for placement:
+                // - Spread "storage" insts across all "storageServers" and warn
+                //   if there aren't enough servers.
+                // - Spread other insts of a given service across all "servers"
+                //   and warn if there aren't enough servers.
+                // - Support `oneOnHnSvcNames` option to have at least one
+                //   instance of those services on the headnode to ease
+                //   development.
+                //
+                // This layout isn't perfect. There is a balance here between
+                // complexity and getting a layout that suffices for
+                // development.
+                //
+                // How it works: It
                 function createLayout(ctx, next) {
                     let imageFromSvcName = self.latestImagesByService();
                     let shards = numFromSvcName['shards'];
@@ -2543,6 +2551,9 @@ maAdm.prototype.dumpConfigCommon = function(options, numFromSvcName, callback) {
 
                     ctx.config = {};
 
+                    // Add an instance of a Manta service to the config
+                    // (`ctx.config`) with the given server, image, and, if
+                    // applicable, shard.
                     let addInst = function(svr, svcName, img, shard) {
                         assertplus.uuid(svr, 'svr');
                         assertplus.string(svcName, 'svcName');
@@ -2573,6 +2584,14 @@ maAdm.prototype.dumpConfigCommon = function(options, numFromSvcName, callback) {
                         }
                     };
 
+                    // For each service:
+                    // - get a count of wanted instances (`numFromSvcName`)
+                    // - for each instance, determine an appropriate server
+                    //   and call `addInst(serverUuid, ...)`.
+                    //
+                    // To somewhat balance instances across all servers, we
+                    // use an index into the servers array, `sIdx`, and advance
+                    // that for each placed instance.
                     for (let svcName of svcs.mSvcNames) {
                         let num = numFromSvcName[svcName];
                         if (!num) {
@@ -2588,6 +2607,8 @@ maAdm.prototype.dumpConfigCommon = function(options, numFromSvcName, callback) {
                             continue;
                         }
 
+                        // Get the array of server UUIDs that we will cycle
+                        // through using `sIdx`.
                         let serverUuids =
                             svcName === 'storage'
                                 ? ctx.storageServerUuids
@@ -2604,6 +2625,9 @@ maAdm.prototype.dumpConfigCommon = function(options, numFromSvcName, callback) {
                         let hnIdx = serverUuids.indexOf(ctx.headnodeUuid);
 
                         // Handle 'storage' service layout independently of `sIdx`.
+                        //
+                        // Dev Note: It would perhaps be clearer to handle
+                        // the 'storage' service output of this for-loop.
                         if (svcName === 'storage') {
                             let ssIdx = 0;
                             if (
@@ -2625,14 +2649,14 @@ maAdm.prototype.dumpConfigCommon = function(options, numFromSvcName, callback) {
                             options.oneOnHnSvcNames.indexOf(svcName) !== -1 &&
                             hnIdx !== -1
                         ) {
-                            // This service wants to ensure at least one instance
-                            // is on the headnode. To handle that we reset the
-                            // server index to the index of the headnode.
+                            // This service wants to ensure at least one
+                            // instance is on the headnode. To handle that we
+                            // reset the server index to the headnode.
                             //
-                            // A limitation due to this is that we aren't equally
-                            // balancing instances across all servers, but then
-                            // we aren't really doing so anyway because services
-                            // differ in capacity requirements.
+                            // A limitation due to this is that we aren't
+                            // equally balancing instances across all servers,
+                            // but then we aren't really doing so anyway because
+                            // services differ in capacity requirements.
                             sIdx = hnIdx;
                         }
 

--- a/lib/adm.js
+++ b/lib/adm.js
@@ -6146,8 +6146,7 @@ maAdm.prototype.createTopology = function createTopology(opts, callback) {
                 assertplus.equal(
                     apps.length,
                     1,
-                    'exactly one ' +
-                        'application should exist with name "manta"'
+                    'exactly one application should exist with name "manta"'
                 );
                 ctx.mantaApp = apps[0];
                 next();

--- a/lib/adm.js
+++ b/lib/adm.js
@@ -2542,8 +2542,6 @@ maAdm.prototype.dumpConfigCommon = function(options, numFromSvcName, callback) {
                 // This layout isn't perfect. There is a balance here between
                 // complexity and getting a layout that suffices for
                 // development.
-                //
-                // How it works: It
                 function createLayout(ctx, next) {
                     let imageFromSvcName = self.latestImagesByService();
                     let shards = numFromSvcName['shards'];

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright 2019 Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  */
 
 /*
@@ -1161,7 +1161,10 @@ function createInstance(deployer, app, svc, cb) {
 
                 sapi.createInstance(svc.uuid, opts, function(err, inst) {
                     if (err) {
-                        log.error(err, 'failed to create instance');
+                        log.error(
+                            {err: err, service: svc.uuid, createOpts: opts},
+                            'failed to create instance'
+                        );
                         subcb(err);
                         return;
                     }


### PR DESCRIPTION
This updates 'manta-deploy-dev' to take and pass through args to
'manta-adm genconfig ... lab' for laying out a Manta "lab" size
deployment across multiple servers. The new lab-size options are:

    -s SERVERS, --servers=SERVERS
                       Specify servers to use for Manta service instances.
                       SERVERS a comma-separated list of server UUIDs. If not
                       specified, the deployment will use *all* available
                       servers.
    -S SERVERS, --storage-servers=SERVERS
                       Specify servers to use for Manta "storage" service
                       instances. SERVERS a comma-separated list of server
                       UUIDs. If not specified, the servers given by "--servers"
                       will be used.
    -1 SVCNAMES, --one-on-headnode=SVCNAMES
                       Specify service names to ensure at least one instance is
                       deployed to the headnode. This is for developer
                       convenience. If not specified, it defaults to:
                       "loadbalancer,webapi,buckets-api"

This also notably changes the default "lab" size to use *all available
setup servers*.

Also, this changes 'manta-adm show -js' and 'manta-adm genconfig lab'
output to be *sorted* (by CN UUID and by service name) so they can
more meaningfully be compared.