### PR TITLE
MANTA-5135 'manta-adm update' must deploy nameservice instances in series

### DIFF
--- a/lib/adm.js
+++ b/lib/adm.js
@@ -5479,8 +5479,10 @@ maAdm.prototype.doExecPlan = function(sout, serr, dryrun, callback) {
                     // is to do nameservice deployments in series, which is
                     // what we do here.
                     concurrency = 1;
-                    log.debug({planInputs: inputs},
-                        'force nameservice deployment to be in series');
+                    log.debug(
+                        {planInputs: inputs},
+                        'force nameservice deployment to be in series'
+                    );
                 } else {
                     concurrency = inputs.length;
                 }

--- a/lib/adm.js
+++ b/lib/adm.js
@@ -5451,6 +5451,7 @@ maAdm.prototype.dumpPlan = function() {
 maAdm.prototype.doExecPlan = function(sout, serr, dryrun, callback) {
     var self = this;
     var count = 0;
+    var log = self.ma_log;
 
     vasync.forEachPipeline(
         {
@@ -5469,8 +5470,22 @@ maAdm.prototype.doExecPlan = function(sout, serr, dryrun, callback) {
                 }
 
                 inputs = Object.keys(self.ma_plan[svcname]);
-                concurrency = dryrun ? 1 : inputs.length;
+                if (dryrun) {
+                    concurrency = 1;
+                } else if (svcname === 'nameservice') {
+                    // The update of <mantaSapiApp>.metadata.ZK_SERVERS in
+                    // Deployer.deploy for nameservice instances is racy if
+                    // multiple instances are done concurrently. One solution
+                    // is to do nameservice deployments in series, which is
+                    // what we do here.
+                    concurrency = 1;
+                    log.debug({planInputs: inputs},
+                        'force nameservice deployment to be in series');
+                } else {
+                    concurrency = inputs.length;
+                }
                 errors = [];
+
                 queue = vasync.queue(function execPlanSvcCn(cnid, queuecb) {
                     if (dryrun) {
                         fprintf(sout, '  cn "%s":\n', cnid);

--- a/lib/adm.js
+++ b/lib/adm.js
@@ -6302,12 +6302,7 @@ maAdm.prototype.createTopology = function createTopology(opts, callback) {
                         next(jsonErr);
                         return;
                     }
-                    self.ma_log.info(
-                        {
-                            serializedRing: serializedRing
-                        },
-                        'generated hash ring'
-                    );
+                    self.ma_log.info('generated hash ring');
                     next();
                 });
             }
@@ -6374,7 +6369,6 @@ maAdm.prototype.createTopology = function createTopology(opts, callback) {
             }
             self.ma_log.info(
                 {
-                    serializedRing: serializedRing,
                     serializedRingLocation: serializedRingLocation
                 },
                 'wrote serialized ring'

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -263,8 +263,11 @@ Deployer.prototype.deploy = function(options, svcname, callback) {
     var allservices;
     var deployer;
 
-    // Dev Note: I don't know why a clone of `this`s data is used here rather
-    // than just `self` directly. -- Trent
+    // Dev Note: *Cloning* `this`s fields to `deployer` and using that below
+    // is odd. The code below uses `deployer` both (a) to call its methods *and*
+    // as a holder of instance-specific *state*, e.g. `deployer.zkId`.
+    // This is gross is should be cleaned up: separating inst state and passing
+    // that through to Deployer methods.
     deployer = {};
     for (var k in this) {
         deployer[k] = this[k];

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -262,6 +262,7 @@ Deployer.prototype.close = function(cb) {
 Deployer.prototype.deploy = function(options, svcname, callback) {
     var allservices;
     var deployer;
+    var self = this;
 
     // Dev Note: *Cloning* `this`s fields to `deployer` and using that below
     // is odd. The code below uses `deployer` both (a) to call its methods *and*
@@ -465,8 +466,10 @@ Deployer.prototype.deploy = function(options, svcname, callback) {
 
                 assert.object(nic, 'nic');
                 assert.string(nic.ip, 'nic.ip');
-                assert.object(deployer.manta_app.metadata,
-                    'deployer.manta_app.metadata');
+                assert.object(
+                    deployer.manta_app.metadata,
+                    'deployer.manta_app.metadata'
+                );
 
                 if (deployer.manta_app.metadata.ZK_SERVERS) {
                     zkServers = deployer.manta_app.metadata.ZK_SERVERS.slice();

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -456,7 +456,7 @@ Deployer.prototype.deploy = function(options, svcname, callback) {
             function updateZKServers(nic, cb) {
                 var sapi = deployer.SAPI;
                 var log = deployer.log;
-                var metadata = {};
+                var zkServers = {};
 
                 if (deployer.svcname !== 'nameservice') {
                     cb(null);
@@ -465,18 +465,16 @@ Deployer.prototype.deploy = function(options, svcname, callback) {
 
                 assert.object(nic, 'nic');
                 assert.string(nic.ip, 'nic.ip');
+                assert.object(deployer.manta_app.metadata,
+                    'deployer.manta_app.metadata');
 
-                if (
-                    deployer.manta_app.metadata &&
-                    deployer.manta_app.metadata.ZK_SERVERS
-                ) {
-                    metadata.ZK_SERVERS =
-                        deployer.manta_app.metadata.ZK_SERVERS;
+                if (deployer.manta_app.metadata.ZK_SERVERS) {
+                    zkServers = deployer.manta_app.metadata.ZK_SERVERS.slice();
                 } else {
-                    metadata.ZK_SERVERS = [];
+                    zkServers = [];
                 }
 
-                var zkId = pickNextZkId(metadata.ZK_SERVERS);
+                var zkId = pickNextZkId(zkServers);
                 if (zkId instanceof Error) {
                     log.error(zkId);
                     cb(zkId);
@@ -484,22 +482,24 @@ Deployer.prototype.deploy = function(options, svcname, callback) {
                 }
                 deployer.zkId = zkId;
 
-                metadata.ZK_SERVERS.push({
+                zkServers.push({
                     host: nic.ip,
                     port: 2181,
                     num: zkId
                 });
 
-                var len = metadata.ZK_SERVERS.length;
+                var len = zkServers.length;
                 for (var ii = 0; ii < len - 1; ii++) {
-                    delete metadata.ZK_SERVERS[ii].last;
+                    delete zkServers[ii].last;
                 }
-                metadata.ZK_SERVERS[len - 1].last = true;
+                zkServers[len - 1].last = true;
 
                 sapi.updateApplication(
                     deployer.manta_app.uuid,
                     {
-                        metadata: metadata
+                        metadata: {
+                            ZK_SERVERS: zkServers
+                        }
                     },
                     function(err, app) {
                         if (err) {
@@ -511,10 +511,16 @@ Deployer.prototype.deploy = function(options, svcname, callback) {
                             );
                         } else {
                             log.info(
-                                {metadata: metadata},
+                                {ZK_SERVERS: zkServers},
                                 'updated ZK_SERVERS on the SAPI "manta" app'
                             );
                             deployer.manta_app = app;
+
+                            // Ensure a possible subsequent nameservice instance
+                            // provision *in this same manta-adm process* has
+                            // the updated ZK_SERVERS.
+                            self.manta_app.metadata.ZK_SERVERS = zkServers;
+
                             cb();
                         }
                     }

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -456,26 +456,23 @@ Deployer.prototype.deploy = function(options, svcname, callback) {
             function updateZKServers(nic, cb) {
                 var sapi = deployer.SAPI;
                 var log = deployer.log;
+                var metadata = {};
 
                 if (deployer.svcname !== 'nameservice') {
                     cb(null);
                     return;
                 }
 
-                log.info(
-                    'updating the list of zk servers in the ' +
-                        'sapi manta application'
-                );
-
                 assert.object(nic, 'nic');
                 assert.string(nic.ip, 'nic.ip');
 
-                var metadata = deployer.manta_app.metadata;
-
-                if (!metadata) {
-                    metadata = {};
-                }
-                if (!metadata.ZK_SERVERS) {
+                if (
+                    deployer.manta_app.metadata &&
+                    deployer.manta_app.metadata.ZK_SERVERS
+                ) {
+                    metadata.ZK_SERVERS =
+                        deployer.manta_app.metadata.ZK_SERVERS;
+                } else {
                     metadata.ZK_SERVERS = [];
                 }
 
@@ -494,24 +491,34 @@ Deployer.prototype.deploy = function(options, svcname, callback) {
                 });
 
                 var len = metadata.ZK_SERVERS.length;
-
                 for (var ii = 0; ii < len - 1; ii++) {
                     delete metadata.ZK_SERVERS[ii].last;
                 }
                 metadata.ZK_SERVERS[len - 1].last = true;
 
-                var opts = {};
-                opts.metadata = metadata;
-
-                sapi.updateApplication(deployer.manta_app.uuid, opts, function(
-                    err,
-                    app
-                ) {
-                    if (!err) {
-                        deployer.manta_app = app;
+                sapi.updateApplication(
+                    deployer.manta_app.uuid,
+                    {
+                        metadata: metadata
+                    },
+                    function(err, app) {
+                        if (err) {
+                            cb(
+                                new VError(
+                                    err,
+                                    'could not update ZK_SERVERS on SAPI manta app'
+                                )
+                            );
+                        } else {
+                            log.info(
+                                {metadata: metadata},
+                                'updated ZK_SERVERS on the SAPI "manta" app'
+                            );
+                            deployer.manta_app = app;
+                            cb();
+                        }
                     }
-                    cb(err);
-                });
+                );
             },
 
             function ensureComputeId(cb) {


### PR DESCRIPTION
Also:
- Improve updateZKServers to only update ZK_SERVERS and not every other
  piece of metadata on the manta app (to avoid large requests and the
  possibility of a race wrecking other recent changes to the app's metadata).
- Remove unhelpful and huge log records that dump the entire electric-moray
  hash ring data.