### PR TITLE
MANTA-5154 Snaplink removal processing fails when a shard has no snaplinks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # sdc-manta changelog
 
+# 1.7.0
+
+- MANTA-5142, MANTA-5154 mantav2-migrate fixes.
+- MANTA-4874 Add 'mantav2-migrate snaplink-cleanup' command for driving
+  snaplink removal, a major part of mantav2 migration.
+
 # 1.6.1
 
 - MANTA-5127 manta-init should check its command line arguments

--- a/lib/mantav2-migrate/migrator.js
+++ b/lib/mantav2-migrate/migrator.js
@@ -615,6 +615,7 @@ Migrator.prototype.ensureDelinkScripts = function ensureDelinkScripts(
                 .toString('utf8')
                 .trim()
                 .split(/\n/g)
+                .filter(line => line)
                 .map(line => JSON.parse(line));
         } catch (parseErr) {
             cb(new VError(parseErr, 'could not load %s', shard.discoveryFile));

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "manta-deployment",
     "description": "Manta deployment configuration",
-    "version": "1.6.1",
+    "version": "1.7.0",
     "author": "Joyent (joyent.com)",
     "license": "MPL-2.0",
     "private": true,

--- a/tools/snaplink-sherlock.sh
+++ b/tools/snaplink-sherlock.sh
@@ -44,7 +44,7 @@ function fatal {
 
 [[ -n ${TARGET} ]] || fatal "Usage: $0 <vm UUID>"
 
-xtrace_log="/tmp/snaplink-sherlock.$(date -u +%Y%m%dT%H%M%S).xtrace.log"
+xtrace_log="/var/tmp/snaplink-sherlock.$(date -u +%Y%m%dT%H%M%S).xtrace.log"
 echo "Writing xtrace output to: ${xtrace_log}" >&2
 exec 4>>$xtrace_log
 BASH_XTRACEFD=4


### PR DESCRIPTION
Also put the snaplink-sherlock trace log on /var/tmp so it is available
for debugging after the sherlock VM is stopped.