### PR TITLE
MANTA-5156 Snaplink removal check does not account for shards with no snaplink

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # sdc-manta changelog
 
+# 1.7.1
+
+- MANTA-5154 'mantav2-migrate snaplink-cleanup' fix when there is a moray
+  index shard with no snaplinks.
+
 # 1.7.0
 
 - MANTA-5142, MANTA-5154 mantav2-migrate fixes.

--- a/lib/mantav2-migrate/migrator.js
+++ b/lib/mantav2-migrate/migrator.js
@@ -600,6 +600,7 @@ Migrator.prototype.ensureDelinkScripts = function ensureDelinkScripts(
     // Work through each discovery file and generate the delink info.
     for (let shardIdx = 0; shardIdx < opts.indexShards.length; shardIdx++) {
         let shard = opts.indexShards[shardIdx];
+        metadataCmdsFromShard[shard.host] = [];
 
         let content;
         let records;
@@ -669,10 +670,6 @@ Migrator.prototype.ensureDelinkScripts = function ensureDelinkScripts(
                     )
                 );
                 return;
-            }
-
-            if (!metadataCmdsFromShard.hasOwnProperty(shard.host)) {
-                metadataCmdsFromShard[shard.host] = [];
             }
 
             // Add a command to update the metadata entry to the new object

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "manta-deployment",
     "description": "Manta deployment configuration",
-    "version": "1.7.0",
+    "version": "1.7.1",
     "author": "Joyent (joyent.com)",
     "license": "MPL-2.0",
     "private": true,


### PR DESCRIPTION
This ensures that a "delink/${shard}_moraydelink.sh" script is made for every index shard (an invariant that is checked), even if it is a no-op.