### PR TITLE
MANTA-5226: pgstatsmon probes time out on buckets deployment

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # sdc-manta changelog
 
+# 1.8.7
+
+- MANTA-5226: pgstatsmon probes time out on buckets deployment.
+
 # 1.8.1
 
 - MANTA-5325 Fix `manta-hotpatch-rebalancer-agent` to work in a multi-DC Manta.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 # 1.8.7
 
-- MANTA-5226: pgstatsmon probes time out on buckets deployment.
+- MANTA-5226: pgstatsmon probes time out on buckets deployment. Changes the default pgstatsmon query timeout from 1s to 10s. This is can now be changed via the `QUERY_TIMEOUT` in SAPI.
 
 # 1.8.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 # 1.8.7
 
-- MANTA-5226: pgstatsmon probes time out on buckets deployment. Changes the default pgstatsmon query timeout from 1s to 10s. This is can now be changed via the `QUERY_TIMEOUT` in SAPI.
+- MANTA-5226: pgstatsmon probes time out on buckets deployment. Changes the default pgstatsmon query timeout from 1s to 10s. This can now be changed via the `QUERY_TIMEOUT` in SAPI.
 
 # 1.8.1
 

--- a/config/services/pgstatsmon/service.json
+++ b/config/services/pgstatsmon/service.json
@@ -9,6 +9,7 @@
 		"VM_TAG_VALUE": "*postgres",
 		"NIC_TAG": "manta",
 		"VMAPI_POLL_INTERVAL": "60000",
+		"QUERY_TIMEOUT": "10000",
 		"SCRAPE_INTERVAL": "60000",
 		"VM_ROLES": [ {
 			"name": "postgres",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
     "name": "manta-deployment",
     "description": "Manta deployment configuration",
-    "version": "1.8.6",
-    "author": "MNX Cloud (mnx.io)",
+    "version": "1.8.7",
+    "author": "Edgecast Cloud (edgecast.io)",
     "license": "MPL-2.0",
     "private": true,
     "dependencies": {


### PR DESCRIPTION
Accompanying change for https://github.com/TritonDataCenter/pgstatsmon/pull/46.

This changes the default from `1000` ms (1s) to `10000` (10s) to allow longer running queries to succeed.

Testing notes are in the ticket.